### PR TITLE
Update tf versions for aws so newer systems with networks can reboot.

### DIFF
--- a/ansible_roles/roles/aws_create/files/tf/main.tf
+++ b/ansible_roles/roles/aws_create/files/tf/main.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.27"
+      version = ">= 4.35"
     }
   }
-  required_version = ">= 0.14.9"
+  required_version = ">= 1.0"
 }


### PR DESCRIPTION
Old version is causing the i4g* and other new platforms not to reboot properly when we are dealing with internal private networks.  Bumping to the latest terraform version clears the issue out.  Not bumping azure/gcp as they are perfectly happy with the current version.