### PR TITLE
Skip PBench installation for local systems

### DIFF
--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -422,6 +422,7 @@
         - config_info.network_required == "yes"
     when:
       - config_info.pbench_install != 0
+      - config_info.system_type != "local"
 
 #
 # Install the packages.


### PR DESCRIPTION
This PR stops pbench_install step from running on local systems, which causes the error message below.

```
fatal: [<HOST> -> {{ target_sys }}]: FAILED! => {"msg": "The field 'delegate_to' has an invalid value, which includes an undefined variable. The error was: {{ dyn_data.net_hostname }}: 'dict object' has no attribute 'net_hostname'\n\nThe error appears to be in '<PATH>': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# Install pbench.repo\n- name: ensure we have the pbench.repo file properly in place\n  ^ here\n"}
```