### PR TITLE
Break up large tests into smaller tests.  Failure to do so, can result

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -1,3 +1,4 @@
+#!/bin/bash
 #                         License
 #
 # Copyright (C) 2022  David Valin dvalin@redhat.com
@@ -200,6 +201,138 @@ gl_no_pbench_install=0
 gl_cpu_type_request="none"
 gl_run_file=""
 
+break_appened_to_file()
+{
+	if [[ -f $1 ]]; then
+		grep -q host_config $1
+		if [ $? -eq 0 ]; then
+			cat $1 >> ${gl_scenario_to_run}.new
+		fi
+		rm $1
+	fi
+}
+
+#
+# break up the large tests if need to.  If the tests get to be too large
+# it can cause problems later by running all the systems in the scenario
+# file at once.
+#
+break_sub_tests()
+{
+	work_file=`mktemp /tmp/zathras_add_in.XXXXX`
+	work_file_header=`mktemp /tmp/zathras_add_in.XXXXX`
+	in_test_section=0
+	test_data=0
+	index=1
+	host_out=0
+	add_in=0
+
+	rm ${gl_scenario_to_run}.new
+	while IFS= read -r line
+	do
+		if [ $in_test_section -ne 1 ]; then
+			if [[ $line == "systems"* ]]; then
+				in_test_section=1
+			fi
+			echo "$line" >> ${gl_scenario_to_run}.new
+			continue
+		fi
+		if [[ $line != "    "* ]]; then
+			if [ $test_data -eq 1 ]; then
+				break_appened_to_file $work_file
+				add_in=0
+			fi
+			if [[ $line == *"system"* ]]; then
+				echo "  system${index}:" >> ${gl_scenario_to_run}.new
+				let "index=$index+1"
+				host_out=1
+			fi
+			continue
+		fi
+		host_len=`echo $line | wc -c`
+		if [[ $line != *"host_config"* ]] || [ $host_len -lt 1024 ]; then
+			echo "$line" >> $work_file
+			test_data=1
+			add_in=1
+			continue
+		fi
+		#
+		# Break up and rebuild
+		#
+		all_hosts=`echo $line | sed "s/,/ /g" | sed "s/\"//g"`
+
+		cp $work_file $work_file_header
+		host_list=""
+		separ=""
+		for hosts in $all_hosts; do
+			if [[ $hosts == *"host_config"* ]]; then
+				continue;
+			fi
+			host_list=${host_list}${separ}${hosts}
+			separ=","
+			hl_len=`echo $host_list | wc -c`
+			if [ $hl_len -gt 1000 ]; then
+				if [[ $host_out -eq 0 ]]; then
+					echo "  system${index}:" >> $work_file
+					let "index=$index+1"
+				fi
+				host_out=1
+				if [ $add_in -eq 0 ]; then
+					cat $work_file_header >> $work_file
+				fi
+				add_in=1
+				echo "    host_config: \"${host_list}\"" >> $work_file
+				echo "  system${index}:" >> $work_file
+				add_in=0
+				let "index=$index+1"
+				echo "    host_config: \"SYS_BARRIER\"" >> $work_file
+				host_list=""
+				separ=""
+			fi
+		done
+		if [[ $host_list != "" ]]; then
+			echo "  system${index}:" >> $work_file
+			let "index=$index+1"
+			if [ $add_in -eq 0 ]; then
+				cat $work_file_header >> $work_file
+			fi
+			add_in=1
+			echo "    host_config: \"${host_list}\"" >> $work_file
+			host_list=""
+		fi
+		break_appened_to_file $work_file
+		add_in=0;
+		test_data=1
+	done < "${gl_scenario_to_run}"
+	break_appened_to_file $work_file
+	add_in=0;
+	if [[ -f ${gl_scenario_to_run}.new ]]; then
+		gl_scenario_to_run=${gl_scenario_to_run}.new
+	fi
+	rm $work_file_header
+}
+
+breakup_large_test()
+{
+#
+# Check to see if we have any large tests
+#
+	if [[ -f ${gl_scenario_to_run}.new ]]; then
+		rm ${gl_scenario_to_run}.new
+	fi
+	while IFS= read -r line
+	do
+		value=`echo $line | wc -c`
+		if [ $value -gt 1024 ]; then
+			break_sub_tests
+			#
+			# No need to check further, we have found a line 
+			# that is too long and have updated the entire file.
+			#
+			break
+		fi
+	done < "${gl_scenario_to_run}"
+}
 #
 # The lock_file is created in tools_bin/update_system.  If we created the lock
 # file, then remove it.
@@ -3782,6 +3915,10 @@ first_invocation()
 		fi
 	fi
 	if [[ $gl_scenario_to_run != "" ]]; then
+		#
+		# Need to make sure the lines do not get to big.
+		#
+		breakup_large_test
 		fields=`grep "\[" ${gl_scenario_to_run}`
 		if [[ $fields != "" ]]; then
 			cleanup_and_exit "Error: following fields in ${gl_scenario_to_run} has no entry in ${gl_config_vars_file}:\n${fields}" 1


### PR DESCRIPTION
in all the systems being created at once.