### PR TITLE
We only want to verify the last results we have.  

### DIFF
--- a/tools_bin/report_missing_failed_test
+++ b/tools_bin/report_missing_failed_test
@@ -45,7 +45,6 @@ if [ -f ${curdir}/failed_test ]; then
 	do
 		while IFS= read -r expt_test
 		do
-
 			list=`grep $sys failed_test | grep $expt_test`
 			if [[ $list != "" ]]; then
 				failed_test=`echo $list | sed "s/Failed: $sys //g"`

--- a/tools_bin/report_missing_failed_test
+++ b/tools_bin/report_missing_failed_test
@@ -10,7 +10,7 @@ do
         do
 		rm -rf tar_check 2> /dev/null
 		mkdir tar_check
-		tball=`ls ${sys}*/results*${expt_test}_t*tar 2> /dev/null`
+		tball=`ls ${sys}*/results*${expt_test}_t*tar | tail -1 2> /dev/null`
 		if [ $? -ne 0 ]; then
 			echo "Missing: $sys $expt_test" >> ${curdir}/missing_test
 			continue
@@ -46,6 +46,7 @@ if [ -f ${curdir}/failed_test ]; then
 	do
 		while IFS= read -r expt_test
 		do
+
 			list=`grep $sys failed_test | grep $expt_test`
 			if [[ $list != "" ]]; then
 				failed_test=`echo $list | sed "s/Failed: $sys //g"`

--- a/tools_bin/report_missing_failed_test
+++ b/tools_bin/report_missing_failed_test
@@ -15,7 +15,6 @@ do
 			echo "Missing: $sys $expt_test" >> ${curdir}/missing_test
 			continue
 		fi
-		tball=`echo $tball | tail -1`
 		#
 		# Untar test results, verify worked.
 		#


### PR DESCRIPTION
Multiple results in the same machine is causing false failure.