### PR TITLE
Fix selinux support.

### DIFF
--- a/ansible_roles/roles/selinux_config/tasks/main.yml
+++ b/ansible_roles/roles/selinux_config/tasks/main.yml
@@ -1,0 +1,94 @@
+---
+#
+# Ubuntu we have to disable and uninstall apparmor and install slinux.
+# This works on 5/17/2024
+#
+- name: Ubuntu enable
+  block:
+  - name: stop apparmor
+    shell: "systemctl stop apparmor"
+  - name: disable apparmor
+    shell:  "systemctl disable apparmor"
+  - name: uninstall app armor
+    shell: "apt-get remove apparmor -y"
+  - name: reboot the system now for disabled aparmor to take effect
+    reboot:
+      reboot_timeout: 1800
+  - name: install selinux on ubuntu
+    shell: "apt-get install policycoreutils selinux-utils selinux-basics -y"
+  - name: Activate selinux
+    shell: "selinux-activate"
+  - name: reboot the system now for selinux to be enabled.
+    reboot:
+      reboot_timeout: 1800
+  - name: We want permissive for selinux
+    shell: "setenforce 0"
+    when: (config_info.selinux_level == "permissive")
+  - name: We want enforcing for selinux
+    fail:
+      msg: "We do not support enforcing on Ubuntu at this time."
+    when: (config_info.selinux_level == "enforcing")
+  - name: reboot the system now to get the proper settings
+    reboot:
+      reboot_timeout: 1800
+  when:
+    - (ansible_facts.selinux.status == 'disabled')
+    - (config_info.selinux_state == "enabled")
+    - (config_info.os_vendor == "ubuntu")
+
+- name: RHEL 2023 selinux
+  block:
+  #
+  # If we do not disable via grubby, there is still some selinux code path we call.
+  #
+  - name: general enablement
+    block:
+    - name: enable selinux RHEL/amazon
+      shell: "grubby --update-kernel=ALL --remove-args=\"selinux\""
+    #
+    # Update the selinux config file
+    # 
+    - name: First get the line to replace
+      shell: "grep ^SELINUX= /etc/selinux/config"
+      register: se_line
+    - name: Remove config_file
+      shell: "rm -rf /tmp/zathras_selinux"
+      ignore_errors: yes
+    - name: If we want to be enforcing
+      shell: "cat /etc/selinux/config | sed \"s/{{ se_line.stdout }}/SELINUX=enforcing/g\" > /tmp/zathras_selinux"
+      ignore_errors: yes
+      when: (config_info.selinux_level == "enforcing")
+    - name: If we want to be permissive
+      shell: "cat /etc/selinux/config | sed \"s/{{ se_line.stdout }}/SELINUX=permissive/g\" > /tmp/zathras_selinux"
+      ignore_errors: yes
+      when: (config_info.selinux_level == "permissive")
+    - name: If we want to be disabled via config
+      shell: "cat /etc/selinux/config | sed \"s/{{ se_line.stdout }}/SELINUX=disabled/g\" > /tmp/zathras_selinux"
+      ignore_errors: yes
+      when: (config_info.selinux_level == "disabled")
+    - name: Move the file if present
+      shell: "mv /tmp/zathras_selinux /etc/selinux/config"
+      ignore_errors: yes
+    - name: reboot the system now to enable selinux
+      reboot:
+        reboot_timeout: 1800
+    when:
+      (config_info.selinux_state == "enabled")
+#
+# If we do not disable via grubby, there is still some selinux code path we call.
+#
+  - name: general disablement
+    block:
+    - name: disabling selinux for RHEL/Amazon
+      shell: "grubby --update-kernel=ALL --args=\"selinux=0\""
+    - name: reboot the system now for disabled selinux to take effect
+      reboot:
+        reboot_timeout: 1800
+    #
+    # For some unkown reason, we ignore the check 
+    # (config_info.selinux_state != "dsiabled") so we will use
+    # (config_info.selinux_state != "enabled")
+    when: (config_info.selinux_state != "enabled")
+  when: 
+    config_info.os_vendor == "rhel" or
+    config_info.os_vendor == "amnazon"

--- a/ansible_roles/roles/selinux_config/tasks/main.yml
+++ b/ansible_roles/roles/selinux_config/tasks/main.yml
@@ -39,7 +39,8 @@
 - name: RHEL 2023 selinux
   block:
   #
-  # If we do not disable via grubby, there is still some selinux code path we call.
+  # By default, grubby does not have selinux in the boot line.  If it is not there
+  # then the system assumes selinux=1
   #
   - name: general enablement
     block:
@@ -79,6 +80,7 @@
       (config_info.selinux_state == "enabled")
 #
 # If we do not disable via grubby, there is still some selinux code path we call.
+# By default, there is no selinux in the grubby boot line.  
 #
   - name: general disablement
     block:

--- a/ansible_roles/roles/selinux_config/tasks/main.yml
+++ b/ansible_roles/roles/selinux_config/tasks/main.yml
@@ -43,8 +43,11 @@
   #
   - name: general enablement
     block:
+    - name: Get name of kernel
+      shell: "uname -r"
+      register: kernel
     - name: enable selinux RHEL/amazon
-      shell: "grubby --update-kernel=ALL --remove-args=\"selinux\""
+      shell: "grubby --update-kernel=/boot/vmlinuz-{{ kernel.stdout }} --remove-args=\"selinux\""
     #
     # Update the selinux config file
     # 
@@ -79,8 +82,11 @@
 #
   - name: general disablement
     block:
+    - name: Get name of kernel
+      shell: "uname -r"
+      register: kernel
     - name: disabling selinux for RHEL/Amazon
-      shell: "grubby --update-kernel=ALL --args=\"selinux=0\""
+      shell: "grubby --update-kernel=/boot/vmlinuz-{{ kernel.stdout }} --args=\"selinux=0\""
     - name: reboot the system now for disabled selinux to take effect
       reboot:
         reboot_timeout: 1800

--- a/bin/burden
+++ b/bin/burden
@@ -45,9 +45,11 @@ export ANSIBLE_ROLES_PATH=$HOME/.ansible/collections/ansible_collections/pbench/
 #   gl_host_config: m5.xlarge
 #   gl_host_config_info: m5.xlarge
 #   host_or_cloud_inst: m5.xlarge
-#   gl_selinux_state: state of selinux
+#   gl_selinux_level: state of selinux
 #     enforcing - SELinux security policy is enforced.
 #     permissive - SELinux prints warnings instead of enforcing.
+#   gl_selinux_state: state of selinux
+#     enabled - SELinux security policy is active.
 #     disabled - No SELinux policy is loaded.
 #   gl_cloud_os_version: Cloud specific, indicates what OS version we are to load.
 #   gl_test_repos: Where we will find the tests to use.
@@ -161,6 +163,7 @@ gl_run_dir_index=0
 gl_run_prefix=""
 gl_scenario_to_run=""
 gl_scenario_to_restore=""
+gl_selinux_level="enforcing"
 gl_selinux_state="enabled"
 gl_selinux_state_set=0
 gl_ssh_key_file=""
@@ -1815,6 +1818,7 @@ create_ansible_options()
 		echo "  spot_start_price: ${gl_spot_price}" >> ansible_vars_main.yml
 		echo "  spot_range: ${spot_pricing}" >> ansible_vars_main.yml
 		echo "  "selinux_state: $gl_selinux_state >> ansible_vars_main.yml
+		echo "  "selinux_level: $gl_selinux_level >> ansible_vars_main.yml
 		user_name=`id | cut -d'(' -f 2 | cut -d')' -f 1`
 		#
 		# Verify the cloud os version is valid
@@ -2318,10 +2322,31 @@ verify_force_upload_value()
 #
 # Verify that the value set for selinux is either enabled or disabled.
 #
-verify_selinux_value()
+verify_selinux_state()
 {
-	if [[ $1 -ne "enabled" ]] && [[ $1 -ne "disabled" ]] ; then
-		cleanup_and_exit "Error: $1, is an unrecognized selinux value.  Valid values are enabled/disabled" 1
+	if [[ $1 -ne "enabled" ]] && [[ $1 -ne "disabled" ]]; then
+		cleanup_and_exit "Error: $1, is an unrecognized selinux state value.  Valid values are enabled/disabled" 1
+	fi
+}
+
+#
+# Verify that the value set for selinux level  is either enforcing, permissive or disabled.
+#
+verify_selinux_level()
+{
+	if [[ $1 -ne "enforcing" ]] && [[ $1 -ne "disabled" ]] && [[ $1 -ne "permissive" ]]; then
+		cleanup_and_exit "Error: $1, is an unrecognized selinux level value.  Valid values are enforcing/permissive/disabled" 1
+	fi
+}
+
+#
+# Ubuntu we do not do enforcing.  Issue is Ubuntu does not have it on by default and to get everything to work properly
+# requires a lot of work, and long reboot times.
+#
+verify_selinux()
+{
+	if [[ $gl_os_vendor == "ubuntu" ]] && [[ $gl_selinux_state == "enabled" ]] && [[ $gl_selinux_level == "enforcing" ]]; then
+		cleanup_and_exit "Error: We do not support enforcing with selinux on ubuntu" 1
 	fi
 }
 
@@ -3368,6 +3393,7 @@ usage()
 	echo "    , then that line is a comment.  If the line starts with a %, it indicates to replace the string."
 	echo "    Format to replace a string  % <current string>=<new string>"
 	echo "  --scenario_vars <file>: file that contains the variables for the scenario file. The default is config/zathras_scenario_vars_def."
+	echo "  --selinux_level: enforcing/permissive/disabled"
 	echo "  --selinux_state: disabled/enabled"
 	echo "  --ssh_key_file: Designates the ssh key file we are to use."
 	echo "  --show_os_versions: given the cloud type, and OS vendor, show the available os versions"
@@ -3627,13 +3653,17 @@ set_general_value()
 			fi
 			shift_by=2
 		;;
+		--selinux_level)
+			gl_selinux_level=$2
+			echo "$1 $gl_selinux_level" >> $gl_cli_supplied_options
+			verify_data verify_selinux_level $gl_selinux_level
+			shift_by=2
+		;;
 		--selinux_state)
-			if [[ $gl_selinux_state_set -eq 0 ]]; then
-				gl_selinux_state_set=1
-				echo "$1 $2" >> $gl_cli_supplied_options
-				gl_selinux_state=$2
-				verify_data verify_selinux_value $gl_selinux_state
-			fi
+			gl_selinux_state_set=1
+			gl_selinux_state=$2
+			echo "$1 $gl_selinux_state" >> $gl_cli_supplied_options
+			verify_data verify_selinux_state $gl_selinux_state
 			shift_by=2
 		;;
 		--show_os_versions)
@@ -3811,6 +3841,7 @@ grab_cli_data()
 		"ssh_key_file"
 		"tuned_profiles"
 		"scenario_vars"
+		"selinux_level"
 		"selinux_state"
 		"system_type"
 		"terminate_cloud"
@@ -4182,6 +4213,8 @@ else
 	gl_test_def_dir=`echo ${gl_test_def_file} | cut -d'/' -f 1-${chars}`
 
 fi
+
+verify_selinux
 
 #
 # Are we looking up the cloud images?

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -711,8 +711,9 @@
       - config_info.os_vendor == "rhel"
       - config_info.update_os_version != "none"
       - config_info.init_system == "yes"
+
 #
-# Disable selinux if required, if we do, reboot the system
+# Perform selinux operations.
 # 
 - hosts: install_group
   user: root
@@ -720,15 +721,9 @@
   vars_files: ansible_vars.yml
   gather_facts: no
   tasks:
-  - name: disable selinux
-    block:
-    - name: disabling selinux
-      selinux:
-        state: disabled
-    - name: reboot the system now for disabled selinux to take effect
-      reboot:
-        reboot_timeout: 1800
-    when: (config_info.selinux_state == "disabled")
+  - name: selinux config
+    include_role:
+      name: selinux_config
 
 #
 # Set sys config values.

--- a/documentation/zathras_doc.adoc
+++ b/documentation/zathras_doc.adoc
@@ -225,7 +225,10 @@ General options
     , then that line is a comment.  If the line starts with a %, it indicates to replace the string.
     Format to replace a string  % &lt;current string&gt;=&lt;new string&gt;
   --scenario_vars &lt;file&gt;: file that contains the variables for the scenario file, default is config/zathras_scenario_vars_def
-  --selinux_state: disabled/enabled
+  --selinux_level: ennforcing/permissive/disabled.  The setting to have in /etc/selinux/config file.  Note: Ubuntu we do not support
+    enforcing at this time.
+  --selinux_state: disabled/enabled.  If disabled is selected, selinux will be disabled via grubby (Amazon and RHEL). For Ubuntu,
+    enabled will install the require packages, update the config file and reboot.
   --ssh_key_file: Designates the ssh key file we are to use.
   --show_os_versions: given the cloud type, and OS vendor, show the available os versions
   --show_tests:  list the available test as defined in config/test_defs.yml


### PR DESCRIPTION
Fix selinux so for Amazon and RHEL 2 ways to disable

First way is via the selinux config file (what we have been doing).
Second way is via grubby, to totally disable selinux.

Also add the ability to designated, enforcing,permissive and disabled.

For Ubuntu add code to install selinux on the OS.  Note at this time, enforcing is not supported.