### PR TITLE
Installer patch - fix yq version, correct ansible package name

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -77,7 +77,7 @@ done
 
 # pip install requirements
 pip3 install boto boto3 --user
-pip3 install 'yq==2.10.0' 
+pip3 install 'yq==2.10.0' --user 
 
 
 echo "Before you can run Zathras:"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -34,7 +34,7 @@ else
 fi
 
 # check for and install system packages
-packages=(ansible git jq python python3-pip terraform wget)
+packages=(ansible-core git jq python python3-pip terraform wget)
 
 for package in "${packages[@]}"; do 
     if dnf list installed "$package" &> /dev/null; then

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -69,7 +69,7 @@ for package in "${packages[@]}"; do
         # install the package
         sudo dnf install terraform -y
     else
-        echo "package is not installed and not available."
+        echo "package $package is not installed and not available."
     fi
 
 done

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -76,7 +76,8 @@ done
 
 
 # pip install requirements
-pip3 install -U boto boto3 yq --user
+pip3 install boto boto3 --user
+pip3 install 'yq==2.10.0' 
 
 
 echo "Before you can run Zathras:"


### PR DESCRIPTION
Changes Python package installation to no longer install latest version of yq because newer versions will break Zathras functionality.

Also corrects package name 'ansible' to 'ansible-core'.