### PR TITLE
Make the results file to download a simple text, and place in zip file.

### DIFF
--- a/ansible_roles/roles/test_execute_loop/tasks/main.yml
+++ b/ansible_roles/roles/test_execute_loop/tasks/main.yml
@@ -19,6 +19,7 @@
       test_exec_loca: "{{ test_location }}"
       test_exec: "{{ test_item }}"
       sys_confg: "tuned_none_sys_file_{{ none }}"
+      tuned: "{{ config_info.rhel_tuned_setting }}"
     loop: "{{ config_info.test_to_run }}"
     loop_control:
       loop_var: test_item

--- a/ansible_roles/roles/test_generic/tasks/main.yml
+++ b/ansible_roles/roles/test_generic/tasks/main.yml
@@ -111,10 +111,10 @@
       block:
       - name: What we are looking for
         debug:
-          msg: "/tmp/results_{{ test_data.test_name }}_{{ sys_confg }}.tar"
+          msg: "/tmp/zathras_{{ test_data.test_name }}.zip"
       - name: retrieve data
         fetch:
-          src: "/tmp/results_{{ test_data.test_name }}_{{ sys_confg }}.tar"
+          src: "/tmp/zathras_{{ test_data.test_name }}.zip"
           dest: "{{ working_dir }}/"
           flat: yes
         ignore_errors: yes

--- a/ansible_roles/roles/test_generic/tasks/main.yml
+++ b/ansible_roles/roles/test_generic/tasks/main.yml
@@ -111,10 +111,10 @@
       block:
       - name: What we are looking for
         debug:
-          msg: "/tmp/zathras_{{ test_data.test_name }}.zip"
+          msg: "/tmp/results_{{ test_data.test_name }}.zip"
       - name: retrieve data
         fetch:
-          src: "/tmp/zathras_{{ test_data.test_name }}.zip"
+          src: "/tmp/results_{{ test_data.test_name }}.zip"
           dest: "{{ working_dir }}/"
           flat: yes
         ignore_errors: yes

--- a/tools_bin/determine_test_status
+++ b/tools_bin/determine_test_status
@@ -15,12 +15,15 @@ determine_tests()
 		#
 		# First check to see if we have a results file.
 		#
-		ls results_${check}_tuned_*tar >>/dev/null 2>&1
+		ls zathras_${check}*zip >>/dev/null 2>&1
 		if [[ $? -ne 0 ]]; then
 			echo ${instance}:${check} no results >> ${curdir}/initial_summary
 			continue
 		fi
-		file=`ls results_${check}_tuned_*tar`
+		file=`unzip -l zathras_${check}.zip | grep tar | awk '{print $4}'`
+		if [ ! -f $file ]; then
+			unzip zathras_${check}*zip
+		fi
 		for tball in $file; do
 			top_dir=`tar --list --file=${tball} | head -1 | cut -d'/' -f 1`
 			tar xf $tball

--- a/tools_bin/determine_test_status
+++ b/tools_bin/determine_test_status
@@ -15,14 +15,14 @@ determine_tests()
 		#
 		# First check to see if we have a results file.
 		#
-		ls zathras_${check}*zip >>/dev/null 2>&1
+		ls results_${check}*zip >>/dev/null 2>&1
 		if [[ $? -ne 0 ]]; then
 			echo ${instance}:${check} no results >> ${curdir}/initial_summary
 			continue
 		fi
-		file=`unzip -l zathras_${check}.zip | grep tar | awk '{print $4}'`
+		file=`unzip -l results_${check}.zip | grep tar | awk '{print $4}'`
 		if [ ! -f $file ]; then
-			unzip zathras_${check}*zip
+			unzip results_${check}*zip
 		fi
 		for tball in $file; do
 			top_dir=`tar --list --file=${tball} | head -1 | cut -d'/' -f 1`


### PR DESCRIPTION
We are having issues in not finding files to download because variations.  Fix by creating a file zathras_"test".zip that contains the tarball.  Zathras will download the zip which is a simple name.  The tar may contain tuned settings, dates etc, and are up to the individual test.  The zip file will be created by the save_results script in the test tools repo.