### PR TITLE
Remove warn line from shell command used to get CRB.  That line now

### DIFF
--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -240,7 +240,6 @@
       - name: get codeready repo name
         shell:
           cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
-          warn: false
         register: repo_name
         ignore_errors: yes
       - name: Record status of yum config sucess


### PR DESCRIPTION
creates an error in ansible, we keep proceeding as if everything is ok, even though we did not execute the requested command.  This in turns causes the CRB not to be enabled.