### PR TITLE
We are not finding the new results file, for ls

### DIFF
--- a/tools_bin/report_missing_failed_test
+++ b/tools_bin/report_missing_failed_test
@@ -10,7 +10,7 @@ do
         do
 		rm -rf tar_check 2> /dev/null
 		mkdir tar_check
-		tball=`ls ${sys}*/results*${expt_test}_t*tar | tail -1 2> /dev/null`
+		tball=`ls ${sys}*/results*${expt_test}_*tar | tail -1 2> /dev/null`
 		if [ $? -ne 0 ]; then
 			echo "Missing: $sys $expt_test" >> ${curdir}/missing_test
 			continue


### PR DESCRIPTION
[We are not finding the new results file, for ls /a45ceeff709a6e20af6ac33f4a8b4bcd90c7b81a) ${sys}*/results*${expt_test}_t*tar, remove the _t