### PR TITLE
Check to see if the file is present before attempting removal

### DIFF
--- a/tools_bin/determine_test_status
+++ b/tools_bin/determine_test_status
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-rm initial_summary all_sys test_summary 2>&1 /dev/null
+for rm_file in initial_summary all_sys test_summary;
+do
+        if [ -f $rm_file ]; then
+                rm $rm_file
+        fi
+done
+
 curdir=`pwd`
 
 determine_tests()

--- a/tools_bin/determine_test_status
+++ b/tools_bin/determine_test_status
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-for rm_file in initial_summary all_sys test_summary;
-do
-        if [ -f $rm_file ]; then
-                rm $rm_file
-        fi
-done
+rm  -f initial_summary all_sys test_summary;
 
 curdir=`pwd`
 


### PR DESCRIPTION
Error messages pertaining to files not being present when trying to remove.  Check first if the file exists then remove it.