### PR TITLE
Right now we are filtering out pbench tests by accident.

### DIFF
--- a/tools_bin/report_missing_failed_test
+++ b/tools_bin/report_missing_failed_test
@@ -12,7 +12,7 @@ done
 curdir=`pwd`
 while IFS= read -r sys
 do
-	grep test_to_run ${sys}*/ansible_vars_main.yml | cut -d'[' -f 2 | cut -d ']' -f 1 | sed "s/,/\n/g" | sort -u > expected_test
+	grep test_to_run ${sys}*/ansible_vars_main.yml | cut -d'[' -f 2 | cut -d ']' -f 1 | sed "s/,/\n/g" | sed "s/pbench_//g" | sort -u > expected_test
 	while IFS= read -r expt_test
         do
 		rm -rf tar_check 2> /dev/null


### PR DESCRIPTION
The archieve script does not know if pbench was used or not (at the level we are at, that knowledge has been lost).  So when we check for test passing, we need to remove pbench_ from the test name.  IE.  pbench_coremark will become just coremark.