### PR TITLE
Do not report past failures, only ones from the current run.

### DIFF
--- a/tools_bin/report_missing_failed_test
+++ b/tools_bin/report_missing_failed_test
@@ -2,7 +2,10 @@
 find . -name ansible_vars_main.yml -print > ans_files
 cut -d '/' -f 2 ans_files | rev | cut -d_  -f 2- | rev | sort -u > systems
 
-rm -f initial_summary all_sys test_summary;
+if [[ -f test_errors ]]; then
+	cat test_errors >> past_errors
+fi
+rm -rf initial_summary all_sys test_summary test_errors tar_check failed_test
 
 curdir=`pwd`
 while IFS= read -r sys
@@ -25,7 +28,8 @@ do
 		tar xf ../$tball $file 2> /dev/null
 		grep -q Ran $file
 		if [ $? -ne 0 ]; then
-			echo "Failed: $sys $expt_test" >> ${curdir}/failed_test
+			fail_run=`echo $tball | cut -d'/' -f 1`
+			echo "Failed: $fail_run $expt_test" >> ${curdir}/failed_test
 		fi
 		rm -rf tar_check
 		cd ..
@@ -49,8 +53,10 @@ if [ -f ${curdir}/failed_test ]; then
 		do
 			list=`grep $sys failed_test | grep $expt_test`
 			if [[ $list != "" ]]; then
-				failed_test=`echo $list | sed "s/Failed: $sys //g"`
-				echo failed:$sys:$failed_test >> test_errors
+				grep -q "$list" past_errors
+				if [ $? -ne 0 ]; then
+					echo $list >> test_errors
+				fi
 			fi
 		done < expected_test
 	done < ${curdir}/systems

--- a/tools_bin/report_missing_failed_test
+++ b/tools_bin/report_missing_failed_test
@@ -2,6 +2,9 @@
 find . -name ansible_vars_main.yml -print > ans_files
 cut -d '/' -f 2 ans_files | rev | cut -d_  -f 2- | rev | sort -u > systems
 
+#
+# Save pasterrors for future reference.
+#
 if [[ -f test_errors ]]; then
 	cat test_errors >> past_errors
 fi


### PR DESCRIPTION
In the old version, we will always report past failures of the tests.  We only want to report what failed in the run we just performed.