### PR TITLE
Move verify_selinux after ami list check

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -4257,8 +4257,6 @@ else
 
 fi
 
-verify_selinux
-
 #
 # Are we looking up the cloud images?
 #
@@ -4275,6 +4273,8 @@ if [[ $gl_show_os_versions -eq 1 ]]; then
 	cloud_image_lookup
 	cleanup_and_exit "" 0
 fi
+
+verify_selinux
 
 #
 # Retrieve the scenario file if need be.


### PR DESCRIPTION
Having verify_selinux before listing the ami's is causing ubuntu to fail in listing the amis, unless we tell zathras that selinux is disabled.  We are not bringing a system up, only listing the amis.  No reason to do that check.