### PR TITLE
Java updates

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -60,7 +60,7 @@ export ANSIBLE_ROLES_PATH=$HOME/.ansible/collections/ansible_collections/pbench/
 #   update_type: what is the update repository (example ftp, iso).
 #   gl_persistent_log: enable persistent logging
 #   gl_ssh_key_file: Points to the ssh config file we are to use.  If not set, we will not use one.
-#   gl_java_version: Version of Java to load:  eg: java-8 or java-11
+#   gl_java_version: Version of Java to load: currently java-8, java-11, java-17, or java-21
 #   gl_rhel_tuned_setting: tuned configuration to use
 #   gl_cloud_execute_tests: If set to 1, we will execute test on the cloud image, else
 #                        we will simply create the image.
@@ -3278,7 +3278,7 @@ usage()
 	echo "    when a repo error occurs."
 	echo "  --individ_vars: Contains various burden settings.  Takes precedence over the scenario file, but is overridden"
 	echo "    by the command line.  Default is config/zathras_specific_vals_def"
-	echo "  --java_version: java version to install, java-8, java-11"
+	echo "  --java_version: java version to install, java-8, java-11, java-17, or java-21"
 	echo "  --kit_upload_directory: Full path to directory uploading to.  If not present, Zathras will locate"
 	echo "    the filesystem with the most space on it and use that location."
 	echo "  --max_systems <n>:  Maximum number of burden subinstances that will be created from the parent.  Each subinstance"

--- a/config/java_pkg_def.yml
+++ b/config/java_pkg_def.yml
@@ -10,3 +10,13 @@ java_defs:
     amazon: java-1.8.0-openjdk
     rhel: java-1.8.0-openjdk-devel
     ubuntu: openjdk-8-jdk
+  java_config3:
+    java_version: java-17
+    amazon: java-17-corretto-headless
+    rhel: java-17-openjdk-headless
+    ubuntu: openjdk-17-jre-headless
+  java_config4:
+    java_version: java-21
+    amazon: java-21-corretto-headless
+    rhel: java-17-openjdk-headless
+    ubuntu: openjdk-21-jre-headless

--- a/config/java_pkg_def.yml
+++ b/config/java_pkg_def.yml
@@ -18,5 +18,5 @@ java_defs:
   java_config4:
     java_version: java-21
     amazon: java-21-corretto-headless
-    rhel: java-17-openjdk-headless
+    rhel: java-21-openjdk-headless
     ubuntu: openjdk-21-jre-headless


### PR DESCRIPTION
This adds support for Java 17 and Java 21.  Package names have been verified by booting the respective OSes in AWS, and I've run a test on a local bare metal host.  One thing this does not do (which the current code does not either) is _force_ the benchmark to use the selected Java version through alternatives on RHEL (I'm assuming there's a method on Ubuntu as well).  There's an odd corner case I've run into where that's problematic (when multiple versions are already installed but the alternative points to the "wrong" one).  Given it's a corner case and easily worked around manually I'd like to see that addressed in a separate PR.