### PR TITLE
Do not view nfs fs as available to use.

### DIFF
--- a/ansible_roles/roles/upload_disk_space/tasks/main.yml
+++ b/ansible_roles/roles/upload_disk_space/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: upload the extra file info, determine location
   block:
   - name: Get the free space
-    command: "ssh -oStrictHostKeyChecking=no {{ dyn_data.ssh_i_option }} {{ config_info.test_user }}@{{ dyn_data.test_hostname }} 'df --output=avail,target,source | grep -v Mounted | grep -v tmpfs | sort -n | tail -1 | xargs | sed \"s/ /:/g\" | cut -d: -f2'"
+    command: "ssh -oStrictHostKeyChecking=no {{ dyn_data.ssh_i_option }} {{ config_info.test_user }}@{{ dyn_data.test_hostname }} 'df --local --output=avail,target,source | grep -v Mounted | grep -v tmpfs | sort -n | tail -1 | xargs | sed \"s/ /:/g\" | cut -d: -f2'"
     register: largest_dir
 
   #


### PR DESCRIPTION
We do not want to consider NFS filesystems as available to upload files to.  Filter out via df --local.