### PR TITLE
Add journalctl -a to boot info.

### DIFF
--- a/tools_bin/gather_boot_info
+++ b/tools_bin/gather_boot_info
@@ -18,4 +18,5 @@ done
 
 systemd-analyze plot > $1_boot_info/bootup.svg
 systemd-analyze dot | dot -Tsvg > $1_boot_info/systemd.svg
+journalctl -a > $1_boot_info/journal_ctl
 tar cf $1_boot_info.tar $1_boot_info


### PR DESCRIPTION
Add journalctl -a output to boot timings.  Right now we are not getting the early boot time information, this will give it to us.