### PR TITLE
Need to install the ansible galaxy package community.aws

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -79,7 +79,16 @@ done
 pip3 install boto boto3 --user
 pip3 install 'yq==2.10.0' --user 
 
-
+#
+# Install required galaxy packages.
+#
+ansible-galaxy collection list | grep -q amazon.aws
+if [ $? -ne 0 ]; then
+	ansible-galaxy collection install community.aws
+else
+	version=`ansible-galaxy collection list | grep amazon.aws`
+	echo Ansible galaxy colletion $version is already installed.
+fi
 echo "Before you can run Zathras:"
 echo "****Ensure ~/.local/bin is in your path"
 echo "****Set up a scenario file"


### PR DESCRIPTION
We are missing the ansible galaxy aws package on the install.  This causes zathras to fail with AWS clouds, in a way that does not really point to anything.

Fix the issue by updating the install script toinstall the appropriate ansible galaxy package.