### PR TITLE
Only check for boto3 if we are doing aws.

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -2134,12 +2134,12 @@ check_for_terraform()
 package_check()
 {
 	check_for_pip3
-	check_for_boto
 	check_for_ansible
 	check_for_yq
 	check_for_jq
 	check_for_python
 	if [[ $gl_system_type == "aws" ]]; then
+		check_for_boto
 		check_for_aws
 	fi
 	check_for_terraform


### PR DESCRIPTION
We only need boto3 for aws, do not perform the check if system type is anything else.

Issue #50
Relates to JIRA: RPOPC-269

