### PR TITLE
Fix the aws cli check to check the existance of the command.

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -2092,10 +2092,11 @@ check_for_python()
 
 check_for_aws()
 {
-	aws_version=`dnf list installed | grep awscli.noarch`
+	aws_version=`aws --version 2> /dev/null`
 	if [[ $? -eq 1 ]]; then
-		cleanup_and_exit "aws requires the aws clis to be installed\ndnf install -y awscli" 1
+		cleanup_and_exit "aws requires the aws CLIs to be installed\ndnf install -y awscli or pip3 install awscli" 1
 	fi
+	aws_version=`echo $aws_version | cut -d'/' -f 2 | cut -d' ' -f 1`
 	report_util_version aws_version "${aws_version}"
 }
 


### PR DESCRIPTION
# Description
Fixes so we check for the existence of the aws command, not if it was installed via dnf.

# Before/After Comparison
Before the change, if the aws command was installed from pip, we would fail as we were checking to see if the package had been installed via dnf.
After the change, we check to see if the aws command is actually present, if not, we flag the error.

# Clerical Stuff
Issue: #141 
Relates to JIRA: RPOPC-282
