### PR TITLE
Uperf requires us to be able to log back in to ourselves.  Fix ssh se…

### DIFF
--- a/ansible_roles/roles/ssh_key_exchange/tasks/main.yml
+++ b/ansible_roles/roles/ssh_key_exchange/tasks/main.yml
@@ -35,6 +35,22 @@
     state: present
     key: "{{ lookup('file','buffer/{{ ip_list[0] }}-id_rsa.pub')}}"
 
+- name: Copy the key add to authorized_keys using Ansible module
+  delegate_to: "{{ ip_list[0] }}"
+  become: yes
+  authorized_key:
+    user: root
+    state: present
+    key: "{{ lookup('file','buffer/{{ ip_list[0] }}-id_rsa.pub')}}"
+
+- name: Copy the key add to authorized_keys using Ansible module
+  delegate_to: "{{ ip_list[1] }}"
+  become: yes
+  authorized_key:
+    user: root
+    state: present
+    key: "{{ lookup('file','buffer/{{ ip_list[1] }}-id_rsa.pub')}}"
+
 - name: Permit root login
   delegate_to: "{{ item }}"
   become: yes


### PR DESCRIPTION
…tup.

# Description
Fixes it so when we set up the networks in the cloud we may ssh back into the system we are logged into.

# Before/After Comparison
Before change:  Uperf test will fail because we can not ssh into the system we are ssh'ing from.
After change: Uperf test works fine.,

# Clerical Stuff
Issue: #148 

Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-293
