### PR TITLE
Quiet ansible

### DIFF
--- a/ansible_roles/roles/log_and_terminate/tasks/main.yml
+++ b/ansible_roles/roles/log_and_terminate/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# tasks file for termination on failure
+
+- name: First,log to the error log
+  cmd: "echo Fatal error: {{ exit_msg }} >> {{ working_dir }}/error_log"
+
+- name: Aborting test
+  fail:
+    msg: "{{ exit_msg }}"
+ 

--- a/ansible_roles/roles/terminate_on_error/tasks/main.yml
+++ b/ansible_roles/roles/terminate_on_error/tasks/main.yml
@@ -20,8 +20,10 @@
     vars:
       tf_dir: "tf"
     when: config_info.cloud_terminate_instance == 1 and config_info.term_system == "yes"
-  - name: Aborting test
-    fail:
-      msg: "{{ exit_msg }}"
+  - name: Log failure
+    include_role:
+      name: log_and_terminate
+    vars:
+      exit_msg: "{{ exit_msg }}"
   when: status.rc == 1
  

--- a/bin/burden
+++ b/bin/burden
@@ -190,7 +190,7 @@ gl_max_systems_set=0
 # should provide a usage.  The --test_version_check option is present
 # so we can only check the versions via an option
 #
-gl_ansible_verboisty="normal"
+gl_ansible_verbosity="normal"
 gl_test_version_check=1
 gl_update_test_versions=0
 gl_disk_iops=0
@@ -1896,8 +1896,8 @@ create_ansible_options()
 			if [[ "$gl_ssh_key_file" != "" ]]; then
 				base_string="${base_string} -s $gl_ssh_key_file"
 			fi
-			if [[ $gl_ansible_verboisty != "normal" ]]; then
-				base_string=${base_string}" -l $gl_ansible_verboisty"
+			if [[ $gl_ansible_verbosity != "normal" ]]; then
+				base_string=${base_string}" -l $gl_ansible_verbosity"
 			fi
 			echo $cli "${arguments[@]}" | sed "s/bin/./g" > ${run_dir}/exec_command
 			test_info_str=`grep test_to_run: $run_dir/ansible_vars_main.yml | sed "s/\[//g" | sed "s/\]//g" | cut -d: -f 2 | sed "s/ //g"`
@@ -3058,7 +3058,7 @@ usage()
 	echo "  --ansible_noise_level <level>: How much information ansible is to output."
 	echo "    normal: standard ansible output"
 	echo "    dense: just report the task executed"
-	echo "    null: nothing reported"
+	echo "    silence: nothing reported"
 	echo "  --archive <dir>/<results>:  location to save the archive information to"
 	echo "  --child: tells burden it is a child of another burden process and not to"
 	echo "    perform the initial setup work"
@@ -3237,10 +3237,10 @@ set_general_value()
 	case "$1" in
 		--ansible_noise_level)
 			echo "$1 $2" >> $gl_cli_supplied_options
-			if [[ $2 != "normal" ]] && [[ $2 != "dense" ]] && [[ $2 != "null" ]]; then
-				cleanup_and_exit "$2 not valid value for --ansible_noise_level.  Valid values are normal, dense or null" 1
+			if [[ $2 != "normal" ]] && [[ $2 != "dense" ]] && [[ $2 != "silence" ]]; then
+				cleanup_and_exit "$2 not valid value for --ansible_noise_level.  Valid values are normal, dense or silence" 1
 			fi
-			gl_ansible_verboisty=$2
+			gl_ansible_verbosity=$2
 			shift_by=2
 		;;
 		--archive)

--- a/bin/burden
+++ b/bin/burden
@@ -1900,12 +1900,18 @@ create_ansible_options()
 				base_string=${base_string}" -l $gl_ansible_verboisty"
 			fi
 			echo $cli "${arguments[@]}" | sed "s/bin/./g" > ${run_dir}/exec_command
+			test_info_str=`grep test_to_run: $run_dir/ansible_vars_main.yml | sed "s/\[//g" | sed "s/\]//g" | cut -d: -f 2 | sed "s/ //g"`
+			echo "Starting ${test_info_str} on ${host_or_cloud_inst}"
 			kick_off.sh $base_string &
-			pids[${pindex}]=$!
+			index=$!
+			pids[${pindex}]="${index}:${test_info_str} on ${host_or_cloud_inst}"
 			let "pindex=$pindex+1"
 			if [[ $pindex -eq $gl_max_systems ]]; then
-				for pid in ${pids[*]}; do
-					wait $pid
+				for pid in "${pids[*]}"; do
+					wait_for=`echo $pid | cut -d ':' -f 1`
+					wait $wait_for
+					out_string=`echo $pid | cut -d ':' -f 2-`
+					echo Finsihed $out_string
 				done
 				pindex=0
 			fi
@@ -1919,8 +1925,11 @@ create_ansible_options()
 	#
 	# Wait for everyone to finish up.
 	#
-	for pid in ${pids[*]}; do
-		wait $pid
+	for pid in "${pids[*]}"; do
+		wait_for=`echo $pid | cut -d ':' -f 1`
+		wait $wait_for
+		out_string=`echo $pid | cut -d ':' -f 2-`
+		echo Finsihed $out_string
 	done
 
 	#

--- a/bin/burden
+++ b/bin/burden
@@ -190,6 +190,7 @@ gl_max_systems_set=0
 # should provide a usage.  The --test_version_check option is present
 # so we can only check the versions via an option
 #
+gl_ansible_verboisty="normal"
 gl_test_version_check=1
 gl_update_test_versions=0
 gl_disk_iops=0
@@ -1895,8 +1896,11 @@ create_ansible_options()
 			if [[ "$gl_ssh_key_file" != "" ]]; then
 				base_string="${base_string} -s $gl_ssh_key_file"
 			fi
+			if [[ $gl_ansible_verboisty != "normal" ]]; then
+				base_string=${base_string}" -l $gl_ansible_verboisty"
+			fi
 			echo $cli "${arguments[@]}" | sed "s/bin/./g" > ${run_dir}/exec_command
-			kick_off.sh $base_string | tee ${run_dir}/ansible_log &
+			kick_off.sh $base_string &
 			pids[${pindex}]=$!
 			let "pindex=$pindex+1"
 			if [[ $pindex -eq $gl_max_systems ]]; then
@@ -3042,6 +3046,10 @@ usage()
 	echo "Usage: $0"
 	echo "Version: "$version
 	echo "General options"
+	echo "  --ansible_noise_level <level>: How much information ansible is to output."
+	echo "    normal: standard ansible output"
+	echo "    dense: just report the task executed"
+	echo "    null: nothing reported"
 	echo "  --archive <dir>/<results>:  location to save the archive information to"
 	echo "  --child: tells burden it is a child of another burden process and not to"
 	echo "    perform the initial setup work"
@@ -3218,6 +3226,14 @@ set_general_value()
 {
 	shift_by=0
 	case "$1" in
+		--ansible_noise_level)
+			echo "$1 $2" >> $gl_cli_supplied_options
+			if [[ $2 != "normal" ]] && [[ $2 != "dense" ]] && [[ $2 != "null" ]]; then
+				cleanup_and_exit "$2 not valid value for --ansible_noise_level.  Valid values are normal, dense or null" 1
+			fi
+			gl_ansible_verboisty=$2
+			shift_by=2
+		;;
 		--archive)
 			if [[ $gl_archive_location == $value_not_set ]]; then
 				gl_archive_location=$2
@@ -3584,6 +3600,7 @@ grab_cli_data()
 	# Define user options
 	#
 	ARGUMENT_LIST=(
+		"ansible_noise_level"
 		"archive"
 		"cloud_os_id"
 		"create_attempts"

--- a/bin/kick_off.sh
+++ b/bin/kick_off.sh
@@ -173,7 +173,14 @@ echo "[defaults]" >> ansible.cfg
 echo "roles_path = ~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/collections/ansible_collections/pbench/agent/roles" >> ansible.cfg
 echo "log_path=${curdir}/ansible_log" >> ansible.cfg
 if [[ $ansible_noise_level != "normal" ]]; then
-	echo "stdout_callback = $ansible_noise_level" >> ansible.cfg
+	if [[ $ansible_noise_level == "silence" ]]; then
+		#
+		# Ansible option for no output is null.
+		#
+		echo "stdout_callback = null" >> ansible.cfg
+	else
+		echo "stdout_callback = $ansible_noise_level" >> ansible.cfg
+	fi
 fi
 current_test=0
 for sys_config in ${individual};

--- a/bin/kick_off.sh
+++ b/bin/kick_off.sh
@@ -89,7 +89,8 @@ spot_recover=1
 create_attempts=5
 remove_dirs=0
 ssh_key_file=""
-while getopts "a:c:d:f:s:rS:t:" o; do
+ansible_noise_level="normal"
+while getopts "a:c:d:f:s:rS:t:l:" o; do
         case "${o}" in
 		a)
 			create_attempts=${OPTARG}
@@ -102,6 +103,9 @@ while getopts "a:c:d:f:s:rS:t:" o; do
 		;;
 		f)
 			tune_file=${OPTARG}
+		;;
+		l)
+			ansible_noise_level=${OPTARG}
 		;;
 		r)
 			remove_dirs=1
@@ -167,6 +171,10 @@ done
 export ANSIBLE_HOST_KEY_CHECKING=False
 echo "[defaults]" >> ansible.cfg
 echo "roles_path = ~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/collections/ansible_collections/pbench/agent/roles" >> ansible.cfg
+echo "log_path=${curdir}/ansible_log" >> ansible.cfg
+if [[ $ansible_noise_level != "normal" ]]; then
+	echo "stdout_callback = $ansible_noise_level" >> ansible.cfg
+fi
 current_test=0
 for sys_config in ${individual};
 do

--- a/documentation/zathras_doc.adoc
+++ b/documentation/zathras_doc.adoc
@@ -132,6 +132,10 @@ $ ./burden --verbose
 Usage: ./bin/burden
 Version: 3.0
 General options
+  --ansible_noise_level: &lt;level&gt;: How much information ansible is to output.
+    normal: standard ansible output
+    dense: just report the task executed
+    null: nothing reported
   --archive &lt;dir&gt;/&lt;results&gt;: location to save the archive information to
   --child: tells burden it is a child of another burden process and not to
     perform the initial setup work

--- a/documentation/zathras_doc.adoc
+++ b/documentation/zathras_doc.adoc
@@ -135,7 +135,7 @@ General options
   --ansible_noise_level: &lt;level&gt;: How much information ansible is to output.
     normal: standard ansible output
     dense: just report the task executed
-    null: nothing reported
+    silence: nothing reported
   --archive &lt;dir&gt;/&lt;results&gt;: location to save the archive information to
   --child: tells burden it is a child of another burden process and not to
     perform the initial setup work


### PR DESCRIPTION
# Description
Introduces the option to remove the huge volume of ansible output.
Three levels: 
    normal: normal output
    dense: just the task being executed
    null: no ansilble output what so ever.


# Clerical Stuff
Issue: #74 


Relates to JIRA: RPOPC-262
