### PR TITLE
Change egrep to grep -E

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -306,7 +306,7 @@ azure_image_lookup()
 	echo "Pulling requested Azure OS image information, may take a bit."
 	end_date=`date +"%Y"`
 	let "start_date=$end_date-1"
-	az vm image list --all --publisher $publisher --output tsv | egrep ".$start_date|.$end_date"
+	az vm image list --all --publisher $publisher --output tsv | grep -E ".$start_date|.$end_date"
 	cleanup_and_exit "" 0
 }
 
@@ -325,7 +325,7 @@ gcp_image_lookup()
 	echo "Pulling requested GCP OS image information, may take a bit."
 	end_date=`date +"%Y"`
 	let "start_date=$end_date-1"
-	gcloud compute images list --format="table(NAME,PROJECT,creationTimestamp.date(tz=LOCAL))" | grep "$project" | egrep ".$start_date|.$end_date"
+	gcloud compute images list --format="table(NAME,PROJECT,creationTimestamp.date(tz=LOCAL))" | grep "$project" | grep -E ".$start_date|.$end_date"
 	cleanup_and_exit "" 0
 }
 
@@ -359,7 +359,7 @@ show_aws_images()
 	if [[ $2 -eq 0 ]]; then
 		echo "Pulling requested AWS OS image information, may take a bit."
 		if [[ $gl_os_vendor != "private" ]]; then
-			aws ec2 describe-images --query 'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]' --filters "$filter" --output table | egrep "${start_date}|${end_date}"
+			aws ec2 describe-images --query 'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]' --filters "$filter" --output table | grep -E "${start_date}|${end_date}"
 		else
 			get_cloud_acct_id
 			aws ec2 describe-images --owners $gl_cloud_acct_id --output table --query 'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]'
@@ -378,7 +378,7 @@ show_aws_images()
 			ami_check=$ami
 			ami_arch=""
 		fi
-		ami_value=`aws ec2 describe-images --query 'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]' --filters "$filter" --output table | egrep "${start_date}|${end_date}" | grep "${ami_check}"`
+		ami_value=`aws ec2 describe-images --query 'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]' --filters "$filter" --output table | grep -E "${start_date}|${end_date}" | grep "${ami_check}"`
 		if [[ $ami_value != "" ]]; then
 			#
 			# check_for_private_amis
@@ -1289,7 +1289,7 @@ aws_specific_os_version()
 		else
 			ami_check=$ami
 		fi
-		ami_value=`aws ec2 describe-images --query 'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]' --filters "$filter" --output table | egrep "${start_date}|${end_date}" | grep "${ami_check}"`
+		ami_value=`aws ec2 describe-images --query 'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]' --filters "$filter" --output table | grep -E "${start_date}|${end_date}" | grep "${ami_check}"`
 		if [[ $ami_value == "" ]]; then
 			get_cloud_acct_id
 			ami_value=`aws ec2 describe-images --owners $gl_cloud_acct_id | grep IMAGES | grep $ami_check`

--- a/tools_bin/data_gather
+++ b/tools_bin/data_gather
@@ -31,7 +31,7 @@ grep "^NUMA node" /tmp/lscpu.tmp
 echo ==============================================
 echo Memory information
 echo ==============================================
-cat /proc/meminfo | egrep "MemTotal:|Hugepagesize:|HardwareCorrupted:"
+cat /proc/meminfo | grep -E "MemTotal:|Hugepagesize:|HardwareCorrupted:"
 echo Numa memory per node
 numactl --hardware | grep size
 #

--- a/tools_bin/get_hw_config
+++ b/tools_bin/get_hw_config
@@ -30,7 +30,7 @@ NUMB_SOCKETS=`grep "Socket(s):" /tmp/lscpu | cut -d: -f 2`
 
 
 cat /sys/devices/system/cpu/cpu*/topology/thread_siblings_list | sort -nu > /tmp/hyper_list
-hyper=`egrep '(-|,)' /tmp/hyper_list`
+hyper=`grep -E '(-|,)' /tmp/hyper_list`
 
 echo numb_cpus: $NUMB_CPUS
 echo cores_per_socket: $CORES_PER_SOCKET
@@ -39,7 +39,7 @@ echo numb_sockets: $NUMB_SOCKETS
 
 cat /sys/devices/system/cpu/cpu*/topology/thread_siblings_list | sort -nu > /tmp/hyper_list
 
-hyper=`egrep '(-|,)' /tmp/hyper_list`
+hyper=`grep -E '(-|,)' /tmp/hyper_list`
 
 
 if [ -z "$hyper" ]; then


### PR DESCRIPTION
# Description
Change egrep to be egrep -E

# Before/After Comparison
We are getting this message while running burden
egrep: warning: egrep is obsolescent; using grep -E

This change removes that warning message.

# Clerical Stuff
Issue: #130

Relates to JIRA: RPOPC-273
