### PR TITLE
Issue Labelling Bugfixes

### DIFF
--- a/.github/workflows/issue_tagging.yaml
+++ b/.github/workflows/issue_tagging.yaml
@@ -9,7 +9,6 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 on:
-  issue_comment:
   pull_request_target:
     types:
       - review_requested
@@ -39,7 +38,7 @@ jobs:
           ) >> $GITHUB_ENV
 
       - name: Fail when unable to find a parent issue
-        if: env.PARENT_ISSUE == ''
+        if: env.PARENT_ISSUES == ''
         run: echo "Could not find a parent issue" && exit 1
 
       - name: Get PR states


### PR DESCRIPTION
# Description
This PR fixes some errors with the Issue Labeling workflow.  For one, it removes the `issue_comment` debug trigger mistakenly committed.  Secondly it fixes a typo in a conditional causing it to never see that a PR has any related issues, causing failure.

# Before/After Comparison
## Before
[Issue Comment Errors](https://github.com/redhat-performance/zathras/actions/runs/12993748129)

[PR Failures](https://github.com/redhat-performance/zathras/pull/156/checks)

## After
Issue comment trigger is removed, so the workflow will not be triggered on issue comments (or PR comments).

The conditional has been updated, causing failure only when it cannot find a parent issue.

# Clerical Stuff
Issue: #158 
Relates to JIRA: RPOPC-315

