### PR TITLE
Enable Reusable workflows

### DIFF
--- a/.github/workflows/check_review_label.yaml
+++ b/.github/workflows/check_review_label.yaml
@@ -1,6 +1,7 @@
 name: Verify group review
 
 on:
+  workflow_call:
   pull_request:
     types:
       - opened

--- a/.github/workflows/issue_tagging.yaml
+++ b/.github/workflows/issue_tagging.yaml
@@ -9,6 +9,7 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 on:
+  workflow_call:
   pull_request_target:
     types:
       - review_requested

--- a/.github/workflows/verify_pr_requirements.yaml
+++ b/.github/workflows/verify_pr_requirements.yaml
@@ -1,6 +1,7 @@
 name: Verify PR has JIRA ticket and issue number
 
 on:
+  workflow_call:
   pull_request:
     types:
       - opened


### PR DESCRIPTION
# Description
This PR allows workflows defined within to be reusable.  This enables us to have a single point of configuration for workflows, instead of having to copy paste them throughout the repositories when CI changes.

# Before/After Comparison
## Before
CI would need to be copied and pasted to each repository, requiring a PR for each change in each repository.

## After
Workflow changes are restricted to this repository, leaving a single point of configuration

# Clerical Stuff
This closes #167 

Relates to JIRA: RPOPC-327
