### PR TITLE
Remove perl package

### DIFF
--- a/config/streams_template.yml
+++ b/config/streams_template.yml
@@ -2,7 +2,7 @@ location: https://github.com/redhat-performance/streams-wrapper/archive/refs/tag
 exec_dir: "streams-wrapper-1.23/streams"
 repo_file: "v1.23.zip"
 os_supported: all
-rhel_pkgs: gcc,bc,perf,git,unzip,perl,perl-Types-UUID.noarch,perf,numactl
+rhel_pkgs: gcc,bc,perf,git,unzip,perf,numactl
 ubuntu_pkgs: gcc,build-essential,libnuma-dev,zip,unzip
 amazon_pkgs: gcc,bc,git,unzip,zip
 test_script_to_run: streams_run


### PR DESCRIPTION
# Description
Removes loading the perl uuid package from the streams config

# Before/After Comparison
Before: streams would load perl uuid, which might fail, we do not use that package.
After: No longer loads that package.

# Clerical Stuff
This closes #177 


Relates to JIRA: RPOPC-349
