### PR TITLE
CI typo hotfix

### DIFF
--- a/.github/workflows/build_ci_container.yaml
+++ b/.github/workflows/build_ci_container.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Login to Quay
-        if: github.event.name == 'push'
+        if: github.event_name == 'push'
         run: docker login quay.io -u ${{ secrets.QUAY_UNAME }} -p ${{ secrets.QUAY_PASSWD }}
         
       - name: Build container


### PR DESCRIPTION
# Description
Fixes a typo in the Jira CI container so it can functionally work.

# Before/After Comparison
## Before
Workflows would skip the login step, preventing the ability to push new releases of the CI image.

## After
Workflows will now log in, and have the ability to push new releases of the CI image.


# Clerical Stuff
This closes #181 

Relates to JIRA: RPOPC-353
