### PR TITLE
Add unzip package

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -36,7 +36,7 @@ else
 fi
 
 # check for and install system packages
-packages=(ansible-core git jq python python3-pip terraform wget)
+packages=(ansible-core git jq python python3-pip terraform unzip wget)
 
 for package in "${packages[@]}"; do 
     if dnf list installed "$package" &> /dev/null; then


### PR DESCRIPTION
# Description
This PR adds the unzip package to the Zathras installation script.

# Before/After Comparison
## Before
Install  8 Packages

Total download size: 5.3 M
Installed size: 20 M
Downloading Packages:
(1/8): python3-ply-3.11-25.el10.noarch.rpm      1.2 MB/s | 134 kB     00:00    
(2/8): python3-cffi-1.16.0-7.el10.x86_64.rpm    1.9 MB/s | 308 kB     00:00    
(3/8): python3-pycparser-2.20-16.el10.noarch.rp 2.6 MB/s | 158 kB     00:00    
(4/8): python3-cryptography-43.0.0-4.el10.x86_6 6.9 MB/s | 1.4 MB     00:00    
(5/8): python3-markupsafe-2.1.3-6.el10.x86_64.r 117 kB/s |  32 kB     00:00    
(6/8): python3-resolvelib-1.0.1-6.el10.noarch.r 465 kB/s |  45 kB     00:00    
(7/8): python3-jinja2-3.1.5-1.el10.noarch.rpm   538 kB/s | 327 kB     00:00    
(8/8): ansible-core-2.16.14-1.el10.noarch.rpm   1.4 MB/s | 2.9 MB     00:02  

## After
Total download size: 5.3 M
Installed size: 20 M
Downloading Packages:
1/8): python3-ply-3.11-25.el10.noarch.rpm      1.2 MB/s | 134 kB     00:00    
(2/8): python3-cffi-1.16.0-7.el10.x86_64.rpm    1.9 MB/s | 308 kB     00:00    
(3/8): python3-pycparser-2.20-16.el10.noarch.rp 2.6 MB/s | 158 kB     00:00    
(4/8): python3-cryptography-43.0.0-4.el10.x86_6 6.9 MB/s | 1.4 MB     00:00    
(5/8): python3-markupsafe-2.1.3-6.el10.x86_64.r 117 kB/s |  32 kB     00:00    
(6/8): python3-resolvelib-1.0.1-6.el10.noarch.r 465 kB/s |  45 kB     00:00    
(7/8): python3-jinja2-3.1.5-1.el10.noarch.rpm   538 kB/s | 327 kB     00:00    
(8/8): ansible-core-2.16.14-1.el10.noarch.rpm   1.4 MB/s | 2.9 MB     00:02  
.
.
.
Installed:
  unzip-6.0-66.el10.x86_64 

# Clerical Stuff
This closes #134 

Relates to JIRA: RPOPC-377
