### PR TITLE
Fix it so we only execute pbench_prep when we are installing pbench.

### DIFF
--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -376,14 +376,17 @@
     - name: Gather the rpm package facts
       package_facts:
         manager: auto
-    - name: pbench prep
-      include_role:
-        name: pbench_prep
-    - name: retrieve pbench prep status
-      include_role:
-        name: retrieve_status
-      vars:
-        status_file: "pbench_prep_status"
+    - name: pbench prep block
+      block:
+      - name: pbench prep
+        include_role:
+          name: pbench_prep
+      - name: retrieve pbench prep status
+        include_role:
+          name: retrieve_status
+        vars:
+          status_file: "pbench_prep_status"
+      when: config_info.pbench_install != 0
     - name: dev environment for uperf
       include_role:
         name: install_dev_environment
@@ -409,6 +412,7 @@
       vars:
         status_file: "pbench_prep_status"
         exit_msg: "pbench prep failure"
+      when: config_info.pbench_install != 0
     - name: Terminate on dev env failure
       include_role:
         name: terminate_on_error


### PR DESCRIPTION
# Description
Stops Zathras from executing pbench prep if we are not installing pbench.

# Before/After Comparison
Before change, possible abort of execution of Zathras because failure in pbench prep, which should never have been called.

After change:  No longer execute pbench prep unless pbench is being installed.  No longer possible abort because of the failure.

# Clerical Stuff
This closes #196 


Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-388
