### PR TITLE
Fix leaving the zahtras gl lock around when updating the test versions.

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -38,8 +38,8 @@
 #
 # For locking for blocks of shell code, we use
 #    Exclusive general lock
-#	To lock: gl_lock_exclusive <locking from, debug only>
-#	To unlock: gl_unlock_exclusive <unlocking from, debug only>
+#	To lock: gl_lock_exclusive
+#	To unlock: gl_unlock_exclusive
 #
 # For locking on a command, we use
 #   flock -x <file name> <command>
@@ -279,32 +279,6 @@ gl_lock=${gl_top_dir}/gl_lock
 gl_have_locked=0
 gl_debug_lock=0
 
-gl_lock_exclusive()
-{
-	if [[ $gl_debug_lock -eq 1 ]]; then
-		echo ${FUNCNAME[1]} ${BASH_LINENO[0]}
-	fi
-	while true
-	do
-		mkdir $gl_lock 2> /dev/null
-		if [[ $? -eq 0 ]]; then
-			gl_have_locked=1
-			break
-		else
-			sleep 4
-		fi
-	done
-}
-
-gl_unlock_exclusive()
-{
-	if [[ $gl_debug_lock -eq 1 ]]; then
-		echo ${FUNCNAME[1]} ${BASH_LINENO[0]}
-	fi
-	rmdir $gl_lock
-	gl_have_locked=0
-}
-
 #
 # Generate report of test status.
 # 
@@ -360,7 +334,7 @@ cleanup_and_exit()
 	# In case we have a lock
 	#
 	if [[ $gl_have_locked -eq 1 ]]; then
-		gl_unlock_exclusive
+		source $UTILS_DIR/gl_unlock_exclusive
 	fi
 	source $UTILS_DIR/cleanup_and_exit_out --fail_report $gl_failed_test_rpt --msg_string "$1" --rtc $rtc --pid $BASHPID $scenario_restore $sysname --top_dir $gl_top_dir
 }
@@ -826,13 +800,13 @@ general_setup()
 	# Only build the tar files once.  Also make sure to only allow one process
 	# operating here.
 	#
-	gl_lock_exclusive
+	source $UTILS_DIR/gl_lock_exclusive
 	if [[ ! -f "bin.tar" ]]; then
 		tar cf bin.tar bin
 		tar cf tools_bin.tar tools_bin
 		tar cf sysctl_settings.tar sysctl_settings
 	fi
-	gl_unlock_exclusive
+	source $UTILS_DIR/gl_unlock_exclusive
 }
 
 #
@@ -1683,7 +1657,7 @@ create_ansible_options()
 		#
 		# Azure, we have a limit on resource group name, need the test_index.
 		#
-		gl_lock_exclusive
+		source $UTILS_DIR/gl_lock_exclusive
 		if [[ $gl_sys_type == "azure" ]]; then
 			run_dir=${gl_run_prefix}/${gl_os_vendor}/${gl_system_type}/${test_index}_${host_or_cloud_inst}
 		else
@@ -1709,7 +1683,7 @@ create_ansible_options()
 
 		echo ${gl_run_prefix}/${gl_os_vendor}/${gl_system_type} >> $gl_run_info
 		make_dir_report_errors $run_dir
-		gl_unlock_exclusive
+		source $UTILS_DIR/gl_unlock_exclusive
 		dir_list=$dir_list$run_dir" "
 		cp ${gl_test_def_dir}/test_defs.yml $run_dir
 		cp ${gl_test_def_dir}/full_test_defs.yml $run_dir
@@ -2253,7 +2227,7 @@ check_for_terraform()
 #
 package_check()
 {
-	gl_lock_exclusive
+	source $UTILS_DIR/gl_lock_exclusive
 	if [[ ! -f utils_version ]]; then
 		check_for_pip3
 		check_for_ansible
@@ -2266,7 +2240,7 @@ package_check()
 		fi
 		check_for_terraform
 	fi
-	gl_unlock_exclusive
+	source $UTILS_DIR/gl_unlock_exclusive
 }
 
 #
@@ -4074,13 +4048,13 @@ first_invocation()
 		fi
 	fi
 
-	gl_lock_exclusive
+	source $UTILS_DIR/gl_lock_exclusive
 	if [[ ! -f test_info ]] || [[ $gl_test_version_check -eq 1 ]] || [[ $gl_update_test_versions -eq 1 ]]; then
 		integrate_templates ${gl_test_def_dir}/test_defs.yml
 		cat $gl_test_def_dir/full_test_defs.yml | yq . > test_info
 		cat $gl_test_def_dir/java_pkg_def.yml | yq . > java_info
 	fi
-	gl_unlock_exclusive
+	source $UTILS_DIR/gl_unlock_exclusive
 }
 
 cli_data="$@"

--- a/bin/utils/cleanup_and_exit_out
+++ b/bin/utils/cleanup_and_exit_out
@@ -182,6 +182,7 @@ cleanup_and_exit_out()
 			mv $from $to
 		done
 	fi
+	source ${UTILS_DIR}/gl_unlock_exclusive
 	exit $rtc
 }
 

--- a/bin/utils/gl_lock_exclusive
+++ b/bin/utils/gl_lock_exclusive
@@ -1,0 +1,13 @@
+if [[ $gl_debug_lock -eq 1 ]]; then
+	echo ${FUNCNAME[1]} ${BASH_LINENO[0]}
+fi
+while true
+do
+	mkdir $gl_lock 2> /dev/null
+	if [[ $? -eq 0 ]]; then
+		gl_have_locked=1
+		break
+	else
+		sleep 4
+	fi
+done

--- a/bin/utils/gl_unlock_exclusive
+++ b/bin/utils/gl_unlock_exclusive
@@ -1,0 +1,7 @@
+if [[ $gl_have_locked -eq 1 ]]; then
+	if [[ $gl_debug_lock -eq 1 ]]; then
+		echo ${FUNCNAME[1]} ${BASH_LINENO[0]}
+	fi
+	rmdir $gl_lock
+	gl_have_locked=0
+fi


### PR DESCRIPTION
# Description
When we do an update_test_versions, we are not removing the global lock burden uses to protect pieces from multiple burdens running at the same time.

# Before/After Comparison
Before change, once you ran with --update_test_versions, any run of burden afterwards would hang trying to get the lock.

After the change, we now remove the lock after --update_test_versions is completed.  This allows ffuture runs of burden in the directory to actually run.


# Clerical Stuff
This closes #194 


Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-386
