### PR TITLE
Do not attempt to Enable CodeReady Builder if we have said no packages.

### DIFF
--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -305,6 +305,7 @@
         - config_info.system_type != "local"
     when:
       - config_info.os_vendor == "rhel"
+      - config_info.do_not_install_packages == 0
 
 - hosts: local
   vars_files: ansible_vars.yml
@@ -316,7 +317,7 @@
     vars:
       status_file: "cr_status"
       exit_msg: "Code repo installation failure"
-    when: (config_info.os_vendor == "rhel") and (config_info.system_type == "aws" or config_info.system_type == "azure" or config_info.system_type == "gcp")
+    when: (config_info.os_vendor == "rhel") and (config_info.do_not_install_packages == 0) and (config_info.system_type == "aws" or config_info.system_type == "azure" or config_info.system_type == "gcp")
 
  #
  # Determine where to upload from, assumption is all test systems have the same


### PR DESCRIPTION
# Description
Prevents doing anything with Enable CodeReady Builder if we are not to load packags.

# Before/After Comparison
Before:  We would attempt to do CodeReady Builder, when no_packages was designated.  This can cause a failure when checking the status file.  We do not want to perform this operation when no_packags is designated.

After:  We no longer attempt to do anything with CodeReady Builder, if no_packatges is designated.
# Clerical Stuff
This closes #203 


Relates to JIRA: RPOPC-414
