### PR TITLE
update iozone options for auto mode

### DIFF
--- a/config/test_defs.yml
+++ b/config/test_defs.yml
@@ -176,8 +176,7 @@ test_defs:
     test_description: iozone
     pbench_required: "no"
     pbench_local_results: "no"
-    test_specific: "--devices_to_use {{ dyn_data.storage }} --filesys xfs --file_count_list 1,2,4 --test_type 0,1 --incache --mount_location /iozone/iozone0"
-
+    test_specific: "--devices_to_use {{ dyn_data.storage }} "--filesys xfs,ext4,ext3  --all_test --mount_location /iozone/iozone0 --eatmem --auto"
   test26:
     test_template: iozone_template.yml
     test_name: pbench_iozone


### PR DESCRIPTION
# Description
Now that auto mode is working and usable and throughput mode is less useful for regression update the default options

# Before/After Comparison
Before: The iozone wrapper sets up runs for a couple of subtests run in throughput mode
After: The iozone wrapper set up runs to mimic the legacy automoation: automatic mode, all I/O types, all subtests, three filesystems

# Clerical Stuff
This closes #205 
Relates to JIRA: RPOPC-433
