### PR TITLE
Remove extra " in the iozone test_defs entry.

### DIFF
--- a/config/test_defs.yml
+++ b/config/test_defs.yml
@@ -176,7 +176,7 @@ test_defs:
     test_description: iozone
     pbench_required: "no"
     pbench_local_results: "no"
-    test_specific: "--devices_to_use {{ dyn_data.storage }} "--filesys xfs,ext4,ext3  --all_test --mount_location /iozone/iozone0 --eatmem --auto"
+    test_specific: "--devices_to_use {{ dyn_data.storage }} --filesys xfs,ext4,ext3  --all_test --mount_location /iozone/iozone0 --eatmem --auto"
   test26:
     test_template: iozone_template.yml
     test_name: pbench_iozone


### PR DESCRIPTION
# Description
There is an extra " in the iozone test_defs entry that is causing the creation of the yq to fail

# Before/After Comparison
Before: Get message
yq: Error running jq: ParserError: while parsing a block mapping
  in "<stdin>", line 554, column 5
did not find expected key
  in "<stdin>", line 574, column 62.


After:
Message is gone.

# Clerical Stuff
This closes #211 

Relates to JIRA: RPOPC-445
