### PR TITLE
Remove labels

### DIFF
--- a/ansible_roles/roles/gcp_create_instance/files/tf/disks.tf
+++ b/ansible_roles/roles/gcp_create_instance/files/tf/disks.tf
@@ -6,11 +6,6 @@ resource "google_compute_disk" "default" {
   type                      = var.disk_type
   zone                      = var.disk_zone
   size                      = var.disk_size
-  labels = {
-    name = var.run_label
-    user = var.User
-    project = var.Project
-  }
 }
 
 # Attaches disks to the instance
@@ -18,9 +13,4 @@ resource "google_compute_attached_disk" "default" {
   count    = var.disk_count * var.vm_count
   disk     = google_compute_disk.default[count.index].id
   instance = google_compute_instance.test[count.index % var.vm_count].id
-  labels = {
-    name = var.run_label
-    user = var.User
-    project = var.Project
-  }
 }


### PR DESCRIPTION
# Description
This PR removes disk label properties from GCP terraform files, fixing the bug reported in #216.

# Before/After Comparison
## Before
```
TASK [tf_create : Display terraform plan] **************************************
ok: [localhost] => {
    "create_plan": {
        "changed": true,
        "cmd": "terraform plan -var-file=env.tfvars -out=plan.tfplan 2>&1 | tee /home/gdumas/gcp-onboarding/results_compute/rhel/gcp/n1-standard-4_5/tf/terraform_plan.out\n",
        "delta": "0:00:00.335053",
        "end": "2025-05-16 13:15:28.234736",
        "failed": false,
        "msg": "",
        "rc": 0,
        "start": "2025-05-16 13:15:27.899683",
        "stderr": "",
        "stderr_lines": [],
        "stdout": "\u001b[31m╷\u001b[0m\u001b[0m\n\u001b[31m│\u001b[0m \u001b[0m\u001b[1m\u001b[31mError: \u001b[0m\u001b[0m\u001b[1mUnsupported argument\u001b[0m\n\u001b[31m│\u001b[0m \u001b[0m\n\u001b[31m│\u001b[0m \u001b[0m\u001b[0m  on disks.tf line 21, in resource \"google_compute_attached_disk\" \"default\":\n\u001b[31m│\u001b[0m \u001b[0m  21:   \u001b[4mlabels\u001b[0m = {\u001b[0m\n\u001b[31m│\u001b[0m \u001b[0m\n\u001b[31m│\u001b[0m \u001b[0mAn argument named \"labels\" is not expected here.\n\u001b[31m╵\u001b[0m\u001b[0m",
        "stdout_lines": [
            "\u001b[31m╷\u001b[0m\u001b[0m",
            "\u001b[31m│\u001b[0m \u001b[0m\u001b[1m\u001b[31mError: \u001b[0m\u001b[0m\u001b[1mUnsupported argument\u001b[0m",
            "\u001b[31m│\u001b[0m \u001b[0m",
            "\u001b[31m│\u001b[0m \u001b[0m\u001b[0m  on disks.tf line 21, in resource \"google_compute_attached_disk\" \"default\":",
            "\u001b[31m│\u001b[0m \u001b[0m  21:   \u001b[4mlabels\u001b[0m = {\u001b[0m",
            "\u001b[31m│\u001b[0m \u001b[0m",
            "\u001b[31m│\u001b[0m \u001b[0mAn argument named \"labels\" is not expected here.",
            "\u001b[31m╵\u001b[0m\u001b[0m"
        ]
    }
}

TASK [tf_create : Bail on failure to create the terraform plan] ****************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed creating the terraform plan"}
```

## After
```
TASK [tf_create : Display terraform plan] **************************************
ok: [localhost] => {
    "create_plan": {
        "changed": true,
        "cmd": "terraform plan -var-file=env.tfvars -out=plan.tfplan 2>&1 | tee /home/gdumas/gcp-onboarding/results_compute/rhel/gcp/n1-standard-4_6/tf/terraform_plan.out\n",
        "delta": "0:00:00.483212",
        "end": "2025-05-19 15:33:57.011242",
        "failed": false,
        "msg": "",
        "rc": 0,
        "start": "2025-05-19 15:33:56.528030",
        "stderr": "",
        "stderr_lines": [],
        "stdout": "\nTerraform used the selected providers to generate the following execution\nplan. Resource actions are indicated with the following symbols:\n  \u001b[32m+\u001b[0m create\u001b[0m\n\nTerraform will perform the following actions:\n\n\u001b[1m  # google_compute_attached_disk.default[0]\u001b[0m will be created\n\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_attached_disk\" \"default\" {\n      \u001b[32m+\u001b[0m\u001b[0m device_name = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m disk        = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m id          = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m instance    = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m mode        = \"READ_WRITE\"\n      \u001b[32m+\u001b[0m\u001b[0m project     = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m zone        = (known after apply)\n    }\n\n\u001b[1m  # google_compute_attached_disk.default[1]\u001b[0m will be created\n\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_attached_disk\" \"default\" {\n      \u001b[32m+\u001b[0m\u001b[0m device_name = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m disk        = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m id          = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m instance    = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m mode        = \"READ_WRITE\"\n      \u001b[32m+\u001b[0m\u001b[0m project     = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m zone        = (known after apply)\n    }\n\n\u001b[1m  # google_compute_disk.default[0]\u001b[0m will be created\n\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_disk\" \"default\" {\n      \u001b[32m+\u001b[0m\u001b[0m creation_timestamp        = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m id                        = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m label_fingerprint         = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m last_attach_timestamp     = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m last_detach_timestamp     = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m name                      = \"disk-pd-ssd-us-central1-c-gdumas-results-compute-rhel-0\"\n      \u001b[32m+\u001b[0m\u001b[0m physical_block_size_bytes = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m project                   = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m self_link                 = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m size                      = 6000\n      \u001b[32m+\u001b[0m\u001b[0m source_image_id           = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m source_snapshot_id        = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m type                      = \"pd-ssd\"\n      \u001b[32m+\u001b[0m\u001b[0m users                     = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m zone                      = \"us-central1-c\"\n    }\n\n\u001b[1m  # google_compute_disk.default[1]\u001b[0m will be created\n\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_disk\" \"default\" {\n      \u001b[32m+\u001b[0m\u001b[0m creation_timestamp        = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m id                        = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m label_fingerprint         = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m last_attach_timestamp     = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m last_detach_timestamp     = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m name                      = \"disk-pd-ssd-us-central1-c-gdumas-results-compute-rhel-1\"\n      \u001b[32m+\u001b[0m\u001b[0m physical_block_size_bytes = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m project                   = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m self_link                 = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m size                      = 6000\n      \u001b[32m+\u001b[0m\u001b[0m source_image_id           = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m source_snapshot_id        = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m type                      = \"pd-ssd\"\n      \u001b[32m+\u001b[0m\u001b[0m users                     = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m zone                      = \"us-central1-c\"\n    }\n\n\u001b[1m  # google_compute_firewall.uperf-ingress[0]\u001b[0m will be created\n\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_firewall\" \"uperf-ingress\" {\n      \u001b[32m+\u001b[0m\u001b[0m creation_timestamp = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m destination_ranges = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m direction          = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m id                 = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m name               = \"gdumas-results-compute-rhel-gdumas-n1-standard-4-0\"\n      \u001b[32m+\u001b[0m\u001b[0m network            = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m priority           = 1000\n      \u001b[32m+\u001b[0m\u001b[0m project            = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m self_link          = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m source_ranges      = (known after apply)\n\n      \u001b[32m+\u001b[0m\u001b[0m allow {\n          \u001b[32m+\u001b[0m\u001b[0m ports    = []\n          \u001b[32m+\u001b[0m\u001b[0m protocol = \"all\"\n        }\n    }\n\n\u001b[1m  # google_compute_instance.test[0]\u001b[0m will be created\n\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_instance\" \"test\" {\n      \u001b[32m+\u001b[0m\u001b[0m allow_stopping_for_update = true\n      \u001b[32m+\u001b[0m\u001b[0m can_ip_forward            = false\n      \u001b[32m+\u001b[0m\u001b[0m cpu_platform              = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m deletion_protection       = false\n      \u001b[32m+\u001b[0m\u001b[0m guest_accelerator         = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m id                        = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m instance_id               = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m label_fingerprint         = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m labels                    = {\n          \u001b[32m+\u001b[0m\u001b[0m \"name\"    = \"gdumas-results-compute-rhel-n1-standard-4\"\n          \u001b[32m+\u001b[0m\u001b[0m \"project\" = \"rhel_regression\"\n          \u001b[32m+\u001b[0m\u001b[0m \"user\"    = \"gdumas\"\n        }\n      \u001b[32m+\u001b[0m\u001b[0m machine_type              = \"n1-standard-4\"\n      \u001b[32m+\u001b[0m\u001b[0m metadata                  = {\n          \u001b[32m+\u001b[0m\u001b[0m \"ssh-keys\" = <<-EOT\n                ...\n            EOT\n        }\n      \u001b[32m+\u001b[0m\u001b[0m metadata_fingerprint      = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m min_cpu_platform          = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m name                      = \"gdumas-results-compute-rhel-gdumas-n1-standard-4-0\"\n      \u001b[32m+\u001b[0m\u001b[0m project                   = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m self_link                 = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m tags_fingerprint          = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m zone                      = \"us-central1-c\"\n\n      \u001b[32m+\u001b[0m\u001b[0m boot_disk {\n          \u001b[32m+\u001b[0m\u001b[0m auto_delete                = true\n          \u001b[32m+\u001b[0m\u001b[0m device_name                = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m disk_encryption_key_sha256 = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m kms_key_self_link          = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m mode                       = \"READ_WRITE\"\n          \u001b[32m+\u001b[0m\u001b[0m source                     = (known after apply)\n\n          \u001b[32m+\u001b[0m\u001b[0m initialize_params {\n              \u001b[32m+\u001b[0m\u001b[0m image  = \"rhel-9-v20250415\"\n              \u001b[32m+\u001b[0m\u001b[0m labels = (known after apply)\n              \u001b[32m+\u001b[0m\u001b[0m size   = (known after apply)\n              \u001b[32m+\u001b[0m\u001b[0m type   = (known after apply)\n            }\n        }\n\n      \u001b[32m+\u001b[0m\u001b[0m network_interface {\n          \u001b[32m+\u001b[0m\u001b[0m name               = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m network            = \"default\"\n          \u001b[32m+\u001b[0m\u001b[0m network_ip         = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m subnetwork         = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m subnetwork_project = (known after apply)\n\n          \u001b[32m+\u001b[0m\u001b[0m access_config {\n              \u001b[32m+\u001b[0m\u001b[0m nat_ip       = (known after apply)\n              \u001b[32m+\u001b[0m\u001b[0m network_tier = (known after apply)\n            }\n        }\n      \u001b[32m+\u001b[0m\u001b[0m network_interface {\n          \u001b[32m+\u001b[0m\u001b[0m name               = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m network            = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m network_ip         = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m subnetwork         = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m subnetwork_project = (known after apply)\n        }\n\n      \u001b[32m+\u001b[0m\u001b[0m scheduling {\n          \u001b[32m+\u001b[0m\u001b[0m automatic_restart   = true\n          \u001b[32m+\u001b[0m\u001b[0m on_host_maintenance = (known after apply)\n          \u001b[32m+\u001b[0m\u001b[0m preemptible         = false\n        }\n    }\n\n\u001b[1m  # google_compute_network.test-network[0]\u001b[0m will be created\n\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_network\" \"test-network\" {\n      \u001b[32m+\u001b[0m\u001b[0m auto_create_subnetworks         = false\n      \u001b[32m+\u001b[0m\u001b[0m delete_default_routes_on_create = false\n      \u001b[32m+\u001b[0m\u001b[0m gateway_ipv4                    = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m id                              = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m ipv4_range                      = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m name                            = \"gdumas-results-compute-rhel-gdumas-n1-standard-4-0\"\n      \u001b[32m+\u001b[0m\u001b[0m project                         = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m routing_mode                    = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m self_link                       = (known after apply)\n    }\n\n\u001b[1m  # google_compute_subnetwork.test-subnet[0]\u001b[0m will be created\n\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_subnetwork\" \"test-subnet\" {\n      \u001b[32m+\u001b[0m\u001b[0m creation_timestamp = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m enable_flow_logs   = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m fingerprint        = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m gateway_address    = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m id                 = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m ip_cidr_range      = \"10.20.30.0/24\"\n      \u001b[32m+\u001b[0m\u001b[0m name               = \"gdumas-results-compute-rhel-gdumas-n1-standard-4-0\"\n      \u001b[32m+\u001b[0m\u001b[0m network            = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m project            = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m region             = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m secondary_ip_range = (known after apply)\n      \u001b[32m+\u001b[0m\u001b[0m self_link          = (known after apply)\n    }\n\n\u001b[1mPlan:\u001b[0m 8 to add, 0 to change, 0 to destroy.\n\u001b[0m\nChanges to Outputs:\n  \u001b[32m+\u001b[0m\u001b[0m internal_ip_list = [\n      \u001b[32m+\u001b[0m\u001b[0m [\n          \u001b[32m+\u001b[0m\u001b[0m (known after apply),\n          \u001b[32m+\u001b[0m\u001b[0m (known after apply),\n        ],\n    ]\n  \u001b[32m+\u001b[0m\u001b[0m public_ip_list   = [\n      \u001b[32m+\u001b[0m\u001b[0m (known after apply),\n    ]\n\u001b[90m\n─────────────────────────────────────────────────────────────────────────────\u001b[0m\n\nSaved the plan to: plan.tfplan\n\nTo perform exactly these actions, run the following command to apply:\n    terraform apply \"plan.tfplan\"",
        "stdout_lines": [
            "",
            "Terraform used the selected providers to generate the following execution",
            "plan. Resource actions are indicated with the following symbols:",
            "  \u001b[32m+\u001b[0m create\u001b[0m",
            "",
            "Terraform will perform the following actions:",
            "",
            "\u001b[1m  # google_compute_attached_disk.default[0]\u001b[0m will be created",
            "\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_attached_disk\" \"default\" {",
            "      \u001b[32m+\u001b[0m\u001b[0m device_name = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m disk        = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m id          = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m instance    = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m mode        = \"READ_WRITE\"",
            "      \u001b[32m+\u001b[0m\u001b[0m project     = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m zone        = (known after apply)",
            "    }",
            "",
            "\u001b[1m  # google_compute_attached_disk.default[1]\u001b[0m will be created",
            "\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_attached_disk\" \"default\" {",
            "      \u001b[32m+\u001b[0m\u001b[0m device_name = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m disk        = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m id          = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m instance    = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m mode        = \"READ_WRITE\"",
            "      \u001b[32m+\u001b[0m\u001b[0m project     = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m zone        = (known after apply)",
            "    }",
            "",
            "\u001b[1m  # google_compute_disk.default[0]\u001b[0m will be created",
            "\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_disk\" \"default\" {",
            "      \u001b[32m+\u001b[0m\u001b[0m creation_timestamp        = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m id                        = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m label_fingerprint         = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m last_attach_timestamp     = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m last_detach_timestamp     = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m name                      = \"disk-pd-ssd-us-central1-c-gdumas-results-compute-rhel-0\"",
            "      \u001b[32m+\u001b[0m\u001b[0m physical_block_size_bytes = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m project                   = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m self_link                 = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m size                      = 6000",
            "      \u001b[32m+\u001b[0m\u001b[0m source_image_id           = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m source_snapshot_id        = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m type                      = \"pd-ssd\"",
            "      \u001b[32m+\u001b[0m\u001b[0m users                     = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m zone                      = \"us-central1-c\"",
            "    }",
            "",
            "\u001b[1m  # google_compute_disk.default[1]\u001b[0m will be created",
            "\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_disk\" \"default\" {",
            "      \u001b[32m+\u001b[0m\u001b[0m creation_timestamp        = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m id                        = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m label_fingerprint         = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m last_attach_timestamp     = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m last_detach_timestamp     = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m name                      = \"disk-pd-ssd-us-central1-c-gdumas-results-compute-rhel-1\"",
            "      \u001b[32m+\u001b[0m\u001b[0m physical_block_size_bytes = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m project                   = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m self_link                 = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m size                      = 6000",
            "      \u001b[32m+\u001b[0m\u001b[0m source_image_id           = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m source_snapshot_id        = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m type                      = \"pd-ssd\"",
            "      \u001b[32m+\u001b[0m\u001b[0m users                     = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m zone                      = \"us-central1-c\"",
            "    }",
            "",
            "\u001b[1m  # google_compute_firewall.uperf-ingress[0]\u001b[0m will be created",
            "\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_firewall\" \"uperf-ingress\" {",
            "      \u001b[32m+\u001b[0m\u001b[0m creation_timestamp = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m destination_ranges = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m direction          = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m id                 = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m name               = \"gdumas-results-compute-rhel-gdumas-n1-standard-4-0\"",
            "      \u001b[32m+\u001b[0m\u001b[0m network            = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m priority           = 1000",
            "      \u001b[32m+\u001b[0m\u001b[0m project            = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m self_link          = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m source_ranges      = (known after apply)",
            "",
            "      \u001b[32m+\u001b[0m\u001b[0m allow {",
            "          \u001b[32m+\u001b[0m\u001b[0m ports    = []",
            "          \u001b[32m+\u001b[0m\u001b[0m protocol = \"all\"",
            "        }",
            "    }",
            "",
            "\u001b[1m  # google_compute_instance.test[0]\u001b[0m will be created",
            "\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_instance\" \"test\" {",
            "      \u001b[32m+\u001b[0m\u001b[0m allow_stopping_for_update = true",
            "      \u001b[32m+\u001b[0m\u001b[0m can_ip_forward            = false",
            "      \u001b[32m+\u001b[0m\u001b[0m cpu_platform              = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m deletion_protection       = false",
            "      \u001b[32m+\u001b[0m\u001b[0m guest_accelerator         = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m id                        = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m instance_id               = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m label_fingerprint         = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m labels                    = {",
            "          \u001b[32m+\u001b[0m\u001b[0m \"name\"    = \"gdumas-results-compute-rhel-n1-standard-4\"",
            "          \u001b[32m+\u001b[0m\u001b[0m \"project\" = \"rhel_regression\"",
            "          \u001b[32m+\u001b[0m\u001b[0m \"user\"    = \"gdumas\"",
            "        }",
            "      \u001b[32m+\u001b[0m\u001b[0m machine_type              = \"n1-standard-4\"",
            "      \u001b[32m+\u001b[0m\u001b[0m metadata                  = {",
            "          \u001b[32m+\u001b[0m\u001b[0m \"ssh-keys\" = <<-EOT",
            "                ...
            "            EOT",
            "        }",
            "      \u001b[32m+\u001b[0m\u001b[0m metadata_fingerprint      = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m min_cpu_platform          = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m name                      = \"gdumas-results-compute-rhel-gdumas-n1-standard-4-0\"",
            "      \u001b[32m+\u001b[0m\u001b[0m project                   = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m self_link                 = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m tags_fingerprint          = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m zone                      = \"us-central1-c\"",
            "",
            "      \u001b[32m+\u001b[0m\u001b[0m boot_disk {",
            "          \u001b[32m+\u001b[0m\u001b[0m auto_delete                = true",
            "          \u001b[32m+\u001b[0m\u001b[0m device_name                = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m disk_encryption_key_sha256 = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m kms_key_self_link          = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m mode                       = \"READ_WRITE\"",
            "          \u001b[32m+\u001b[0m\u001b[0m source                     = (known after apply)",
            "",
            "          \u001b[32m+\u001b[0m\u001b[0m initialize_params {",
            "              \u001b[32m+\u001b[0m\u001b[0m image  = \"rhel-9-v20250415\"",
            "              \u001b[32m+\u001b[0m\u001b[0m labels = (known after apply)",
            "              \u001b[32m+\u001b[0m\u001b[0m size   = (known after apply)",
            "              \u001b[32m+\u001b[0m\u001b[0m type   = (known after apply)",
            "            }",
            "        }",
            "",
            "      \u001b[32m+\u001b[0m\u001b[0m network_interface {",
            "          \u001b[32m+\u001b[0m\u001b[0m name               = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m network            = \"default\"",
            "          \u001b[32m+\u001b[0m\u001b[0m network_ip         = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m subnetwork         = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m subnetwork_project = (known after apply)",
            "",
            "          \u001b[32m+\u001b[0m\u001b[0m access_config {",
            "              \u001b[32m+\u001b[0m\u001b[0m nat_ip       = (known after apply)",
            "              \u001b[32m+\u001b[0m\u001b[0m network_tier = (known after apply)",
            "            }",
            "        }",
            "      \u001b[32m+\u001b[0m\u001b[0m network_interface {",
            "          \u001b[32m+\u001b[0m\u001b[0m name               = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m network            = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m network_ip         = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m subnetwork         = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m subnetwork_project = (known after apply)",
            "        }",
            "",
            "      \u001b[32m+\u001b[0m\u001b[0m scheduling {",
            "          \u001b[32m+\u001b[0m\u001b[0m automatic_restart   = true",
            "          \u001b[32m+\u001b[0m\u001b[0m on_host_maintenance = (known after apply)",
            "          \u001b[32m+\u001b[0m\u001b[0m preemptible         = false",
            "        }",
            "    }",
            "",
            "\u001b[1m  # google_compute_network.test-network[0]\u001b[0m will be created",
            "\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_network\" \"test-network\" {",
            "      \u001b[32m+\u001b[0m\u001b[0m auto_create_subnetworks         = false",
            "      \u001b[32m+\u001b[0m\u001b[0m delete_default_routes_on_create = false",
            "      \u001b[32m+\u001b[0m\u001b[0m gateway_ipv4                    = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m id                              = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m ipv4_range                      = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m name                            = \"gdumas-results-compute-rhel-gdumas-n1-standard-4-0\"",
            "      \u001b[32m+\u001b[0m\u001b[0m project                         = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m routing_mode                    = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m self_link                       = (known after apply)",
            "    }",
            "",
            "\u001b[1m  # google_compute_subnetwork.test-subnet[0]\u001b[0m will be created",
            "\u001b[0m  \u001b[32m+\u001b[0m\u001b[0m resource \"google_compute_subnetwork\" \"test-subnet\" {",
            "      \u001b[32m+\u001b[0m\u001b[0m creation_timestamp = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m enable_flow_logs   = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m fingerprint        = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m gateway_address    = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m id                 = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m ip_cidr_range      = \"10.20.30.0/24\"",
            "      \u001b[32m+\u001b[0m\u001b[0m name               = \"gdumas-results-compute-rhel-gdumas-n1-standard-4-0\"",
            "      \u001b[32m+\u001b[0m\u001b[0m network            = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m project            = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m region             = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m secondary_ip_range = (known after apply)",
            "      \u001b[32m+\u001b[0m\u001b[0m self_link          = (known after apply)",
            "    }",
            "",
            "\u001b[1mPlan:\u001b[0m 8 to add, 0 to change, 0 to destroy.",
            "\u001b[0m",
            "Changes to Outputs:",
            "  \u001b[32m+\u001b[0m\u001b[0m internal_ip_list = [",
            "      \u001b[32m+\u001b[0m\u001b[0m [",
            "          \u001b[32m+\u001b[0m\u001b[0m (known after apply),",
            "          \u001b[32m+\u001b[0m\u001b[0m (known after apply),",
            "        ],",
            "    ]",
            "  \u001b[32m+\u001b[0m\u001b[0m public_ip_list   = [",
            "      \u001b[32m+\u001b[0m\u001b[0m (known after apply),",
            "    ]",
            "\u001b[90m",
            "─────────────────────────────────────────────────────────────────────────────\u001b[0m",
            "",
            "Saved the plan to: plan.tfplan",
            "",
            "To perform exactly these actions, run the following command to apply:",
            "    terraform apply \"plan.tfplan\""
        ]
    }
}

TASK [tf_create : Bail on failure to create the terraform plan] ****************
skipping: [localhost]

```

# Clerical Stuff
This closes #216.

Relates to JIRA: RPOPC-453
