### PR TITLE
Fix copying the SSH public key to VM

### DIFF
--- a/ansible_roles/roles/gcp_create_instance/files/tf/main.tf
+++ b/ansible_roles/roles/gcp_create_instance/files/tf/main.tf
@@ -69,7 +69,7 @@ resource "google_compute_instance" "test" {
 
   # copies ssh public key into the system for ssh access to the VM
   metadata = {
-    ssh-keys = "${var.test_user}:${file(var.ssh_key_path)}"
+    ssh-keys = "${var.test_user}:${file("${var.ssh_key_path}.pub")}"
   }
 
   # Ensures that instance is created after successful creation of networks


### PR DESCRIPTION
# Description
This PR fixes an issue where Zathras would not properly copy the SSH keys for access to a Google Cloud Platform (GCP) VM. 

Note: the syntax of this code was generated using Claude Code, then tested by a human.

# Before/After Comparison
## Before
```
TASK [gcp_create_instance : Create user's bin dir if it doesn't already exist] ***
failed: [localhost -> 34.42.77.64] (item=34.42.77.64) => {"ansible_loop_var": "item", "item": "34.42.77.64", "msg": "Failed to connect to the host via ssh: Warning: Permanently added '34.42.77.64' (ED25519) to the list of known hosts.\r\ngdumas@34.42.77.64: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).", "unreachable": true}
fatal: [localhost -> {{ item }}]: UNREACHABLE! => {"changed": false, "msg": "All items completed", "results": [{"ansible_loop_var": "item", "item": "34.42.77.64", "msg": "Failed to connect to the host via ssh: Warning: Permanently added '34.42.77.64' (ED25519) to the list of known hosts.\r\ngdumas@34.42.77.64: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).", "unreachable": true}]}
```

## After
```
TASK [gcp_create_instance : Create user's bin dir if it doesn't already exist] ***
changed: [localhost -> 34.63.78.46] => (item=34.63.78.46)
```
Subsequent test setup stages complete, followed by run success.

# Clerical Stuff
This PR closes #225. 

Relates to JIRA: RPOPC-491
