### PR TITLE
Add user account validation post SSH availability.

### DIFF
--- a/ansible_roles/roles/gcp_create_instance/tasks/main.yml
+++ b/ansible_roles/roles/gcp_create_instance/tasks/main.yml
@@ -78,7 +78,7 @@
   shell : |
     ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \
-    {{ config_info.test_user }}@{{ item }} \
+    {{ config_info.test_user }}@{{ item.1 }} \
     "id {{ config_info.test_user }} && echo 'User ready'"
   register: user_ssh_ready
   until: user_ssh_ready.rc == 0

--- a/ansible_roles/roles/gcp_create_instance/tasks/main.yml
+++ b/ansible_roles/roles/gcp_create_instance/tasks/main.yml
@@ -71,6 +71,23 @@
     delay=10
     timeout=1200
 
+
+# User account validation with exponential backoff retry logic
+# This solves GCP race condition where SSH port becomes available before user accounts are created
+- name: Wait for GCP user account readiness with backoff
+  shell : |
+    ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    {{ config_info.test_user }}@{{ item }} \
+    "id {{ config_info.test_user }} && echo 'User ready'"
+  register: user_ssh_ready
+  until: user_ssh_ready.rc == 0
+  retries: "{{ ansible_ssh_retries | default(5) }}"
+  delay: "{{ item.0 * 2 + 3 }}"  # exponential backoff: 3, 5, 7, 9...
+  with_indexed_items:
+    - "{{ public_ip_list }}" 
+
+
 - name: Create user's bin dir if it doesn't already exist
   delegate_to: "{{ item }}"
   file:


### PR DESCRIPTION
# Description
This PR addresses a race condition that can occur where Zathras attempts to SSH into a Google Cloup Platform (GCP) VM before the user account creation process has finished, causing the test run to fail. Zathras will now retry the SSH a set number of times with exponential backoff after each attempt before failing, which allows time for the VM to finish coming up. The variable length of wait time was chosen in order to account for variability in VM startup time based on network conditions and VM size.

# Before/After Comparison
## Before
```
...
TASK [gcp_create_instance : wait for ssh to come up] ***************************
ok: [localhost]

TASK [gcp_create_instance : Create user's bin dir if it doesn't already exist] ***
failed: [localhost -> 34.122.171.94] (item=34.122.171.94) => {"ansible_loop_var": "item", "item": "34.122.171.94", "msg": "Failed to connect to the host via ssh: Warning: Permanently added '34.122.171.94' (ED25519) to the list of known hosts.\r\ngdumas@34.122.171.94: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).", "unreachable": true}
fatal: [localhost -> {{ item }}]: UNREACHABLE! => {"changed": false, "msg": "All items completed", "results": [{"ansible_loop_var": "item", "item": "34.122.171.94", "msg": "Failed to connect to the host via ssh: Warning: Permanently added '34.122.171.94' (ED25519) to the list of known hosts.\r\ngdumas@34.122.171.94: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).", "unreachable": true}]}

PLAY RECAP *********************************************************************
localhost                  : ok=30   changed=17   unreachable=1    failed=0    skipped=11   rescued=0    ignored=0   

Error: test started, system died.
Finished coremark on n1-standard-4
```

## After
The first SSH attempt fails, but the second succeeds.
```
TASK [gcp_create_instance : Wait for GCP user account readiness with backoff] ***
FAILED - RETRYING: [localhost]: Wait for GCP user account readiness with backoff (15 retries left).
changed: [localhost] => (item=[0, '34.56.71.230'])

TASK [gcp_create_instance : Create user's bin dir if it doesn't already exist] ***
changed: [localhost -> 34.56.71.230] => (item=34.56.71.230)
```


# Clerical Stuff
This closes #229 

Relates to JIRA: RPOPC-495
