### PR TITLE
Add error handling for unsupported systems

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -57,6 +57,11 @@ for package in "${packages[@]}"; do
             release='RHEL'
         elif [ $os_release_clean = 'fedora' ]; then
             release='fedora'
+        else
+            echo "Error: Terraform installation is only supported on RHEL and Fedora distributions."
+            echo "Detected OS: $os_release_clean"
+            echo "Please install Terraform manually from https://developer.hashicorp.com/terraform/install"
+            exit 1
         fi
             # repo URL for terraform
             repo_url="https://rpm.releases.hashicorp.com/${release}/hashicorp.repo"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -28,7 +28,7 @@ set -eu
 # - Test brackets are only needed for comparisons like [[ "$a" == "$b" ]] or [[ -f "$file" ]]
 if ! command -v dnf &> /dev/null; then
     echo "Error: This script requires the DNF package manager."
-    echo "Supported distributions: RHEL 8+, Fedora, CentOS 8+, Rocky Linux, AlmaLinux"
+    echo "Installer supported distributions: RHEL 8+, Fedora"
     echo "For other distributions, please install the required packages manually:"
     echo "  - ansible-core, git, jq, python, python3-pip, terraform, unzip, wget"
     exit 1

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -63,14 +63,15 @@ for package in "${packages[@]}"; do
             echo "Please install Terraform manually from https://developer.hashicorp.com/terraform/install"
             exit 1
         fi
-            # repo URL for terraform
-            repo_url="https://rpm.releases.hashicorp.com/${release}/hashicorp.repo"
 
-            # run dnf config-manager
-            sudo dnf config-manager --add-repo "$repo_url" || {
-                echo "Error: Failed to add HashiCorp repository"
-                exit 1
-            }
+        # repo URL for terraform
+        repo_url="https://rpm.releases.hashicorp.com/${release}/hashicorp.repo"
+
+        # run dnf config-manager
+        sudo dnf config-manager --add-repo "$repo_url" || {
+            echo "Error: Failed to add HashiCorp repository"
+            exit 1
+        }
 
         # install the package
         sudo dnf install terraform-1.9.8-1 -y || {

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -30,7 +30,7 @@ if ! command -v dnf &> /dev/null; then
     echo "Error: This script requires the DNF package manager."
     echo "Installer supported distributions: RHEL 8+, Fedora"
     echo "For other distributions, please install the required packages manually:"
-    echo "  - ansible-core, git, jq, python, python3-pip, terraform, unzip, wget"
+    echo "  ansible-core, git, jq, python, python3-pip, terraform, unzip, wget"
     exit 1
 fi
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -50,12 +50,12 @@ for package in "${packages[@]}"; do
         os_release=$(grep "^ID=" /etc/os-release | awk -F'=' '{print $2}')
 
         # Sometimes the $release contains quotes that need to be removed
-        os_release_clean=$(echo $os_release | tr -d '"')
+        os_release_clean=$(echo "$os_release" | tr -d '"')
 
         # HashiCorp repo urls are case-sensitive
-        if [ $os_release_clean = 'rhel' ]; then
+        if [[ "$os_release_clean" == "rhel" ]]; then
             release='RHEL'
-        elif [ $os_release_clean = 'fedora' ]; then
+        elif [[ "$os_release_clean" == "fedora" ]]; then
             release='fedora'
         else
             echo "Error: Terraform installation is only supported on RHEL and Fedora distributions."

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -19,6 +19,15 @@
 
 set -eu
 
+# Check if dnf package manager is available
+if ! command -v dnf &> /dev/null; then
+    echo "Error: This script requires the DNF package manager."
+    echo "Supported distributions: RHEL 8+, Fedora, CentOS 8+, Rocky Linux, AlmaLinux"
+    echo "For other distributions, please install the required packages manually:"
+    echo "  - ansible-core, git, jq, python, python3-pip, terraform, unzip, wget"
+    exit 1
+fi
+
 # Check if script is being run as root
 if (( $EUID == 0 )); then
     read -p "For most use cases, running this script as root is NOT recommended. Are you sure? Y/N " yesno

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -67,10 +67,14 @@ for package in "${packages[@]}"; do
             repo_url="https://rpm.releases.hashicorp.com/${release}/hashicorp.repo"
 
             # run dnf config-manager
-            sudo dnf config-manager --add-repo $repo_url
+            sudo dnf config-manager --add-repo "$repo_url" || {
+                echo "Error: Failed to add HashiCorp repository"
+                exit 1
+            }
 
         # install the package
         sudo dnf install terraform-1.9.8-1 -y || {
+            echo "Error: Failed to install Terraform"
             exit 1
         }
     else

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -20,6 +20,12 @@
 set -eu
 
 # Check if dnf package manager is available
+# Note: [[ ]] brackets are NOT needed here because:
+# - 'if' statements work directly with command exit codes (0 = success, non-zero = failure)
+# - 'command -v dnf' returns exit code 0 if dnf exists, non-zero if not found
+# - The '!' negates the exit code result
+# - '&> /dev/null' suppresses output while preserving the exit status
+# - Test brackets are only needed for comparisons like [[ "$a" == "$b" ]] or [[ -f "$file" ]]
 if ! command -v dnf &> /dev/null; then
     echo "Error: This script requires the DNF package manager."
     echo "Supported distributions: RHEL 8+, Fedora, CentOS 8+, Rocky Linux, AlmaLinux"


### PR DESCRIPTION
# Description
Currently Zathras installation support is only planned for Fedora and RHEL. This PR adds error handling for unsupported systems in two ways.

First, it requires the installation destination to have the DNF package manager. DNF is required by subsequent installation steps, and if not present, will fail quickly rather than attempting some setup steps.

Second, it cleans up the logic around Terraform installation so that installation on unsupported systems results in a clear error message.

The code changes were created with assistance from Cursor, using Claude AI. Testing was performed by a human. 

This is some of the first AI-assisted code being introduced into the project - let's examine and discuss its inclusion carefully. Should there be a different process for AI generated or assisted code? Additional testing steps? Labels - on commits, PRs?

# Before/After Comparison
Tested on a system with DNF package manager (CentOS) and a non-DNF system (Ubuntu).

## Ubuntu (non-DNF system)
### Before
```
tester@ubuntu:~/zathras $./bin/install.sh
Not running as root, proceed.
Installing ansible-core...
[sudo] password for tester:
sudo: dnf: command not found
```

### After
```
tester@ubuntu:~/zathras $./bin/install.sh
Error: This script requires the DNF package manager.
Supported distributions: RHEL 8+, Fedora, CentOS 8+, Rocky Linux, AlmaLinux
For other distributions, please install the required packages manually:
  - ansible-core, git, jq, python, python3-pip, terraform, unzip, wget
```

## CentOS (DNF system, but not supported for terraform)
### Before:
Installation begins without error, but fails to install Terraform without clear error message.
```
...
python-pip3 is installed.
./bin/install.sh: line 62: release: unbound variable
```

### After:
Installation begins without error, fails on Terraform install with clear error message.
```
...
python3-pip is installed.
Error: Terraform installation is only supported on RHEL and Fedora distributions.
Please install Terraform manually from https://developer.hashicorp.com/terraform/install
```

## RHEL (DNF, Terraform support)
### Before
Install works as expected.

### After
Install works as expected.

# Clerical Stuff
Closes #232 

Relates to JIRA: RPOPC-498
