### PR TITLE
Add installation of Dev packages.

### DIFF
--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -388,6 +388,14 @@
         vars:
           status_file: "pbench_prep_status"
       when: config_info.pbench_install != 0
+    - name: Install the dev environment
+      include_role:
+        name: install_dev_environment
+    - name: retrieve dev env status
+      include_role:
+        name: retrieve_status
+      vars:
+        status_file: "dev_env_status"
     when:
       - config_info.os_vendor == "rhel"
       - config_info.init_system == "yes"
@@ -406,6 +414,12 @@
         status_file: "pbench_prep_status"
         exit_msg: "pbench prep failure"
       when: config_info.pbench_install != 0
+    - name: Terminate on dev env failure
+      include_role:
+        name: terminate_on_error
+      vars:
+        status_file: "dev_env_status"
+        exit_msg: "Failure on dev environment."
     when:
       - config_info.os_vendor == "rhel"
       - config_info.init_system == "yes"


### PR DESCRIPTION
# Description
This places back into Zathras the installation of the @Development Tools.  The ansible task for this has always been there, but the call to you it was removed by accident sometime in the past.

# Before/After Comparison
Before:  Things worked for a bit, but with the new release of RHEL, we ended up missing commands that we expected to be there. gcc, make, zip etc.
After:   The commands we expected to be there, are now present.

# Clerical Stuff
This closes #236 

Relates to JIRA: RPOPC-527

# Testing
1) Verified the package is installed when it is suppose to be.
2) Verified that bare metal systems behave properly with the --no_packages option.
3) Verified if we can not find the Dev package, that the installation fails.
