### PR TITLE
Hotfix: Fix PullHero Enviornment for issue_comments

### DIFF
--- a/.github/workflows/pullhero.yaml
+++ b/.github/workflows/pullhero.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install pullhero
-        run: pip3 install "pullhero<1.0.0" || (echo "::error title=Pullhero Error::Pullhero failed to install" && exit 1)
+        run: pip3 install "pullhero<1.0.0" gitingest[server] || (echo "::error title=Pullhero Error::Pullhero failed to install" && exit 1)
       
       - name: Verify jq is installed
         run: |

--- a/.github/workflows/pullhero.yaml
+++ b/.github/workflows/pullhero.yaml
@@ -50,6 +50,8 @@ jobs:
       
       - name: Get PR Details (comment)
         if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "PR_NUMBER=$(jq -r '.issue.number' $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
           

--- a/.github/workflows/pullhero.yaml
+++ b/.github/workflows/pullhero.yaml
@@ -13,7 +13,7 @@
 
 on:
   pull_request:
-    types: [opened, review_requested]
+    types: [review_requested]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
# Description
This PR fixes the environment variable needed for `gh` in the pullhero workflow for issue_comment

This also fixes broken dependency issues with pullhero, which will eventually be fixed upstream

# Before/After Comparison
## Before
Pullhero issue_comment is broken

## After
Pullhero issue_comment is working

# Clerical Stuff
Fixes #238 
Relates to JIRA: RPOPC-533
