### PR TITLE
Remove unneeded line.

### DIFF
--- a/config/pig_template.yml
+++ b/config/pig_template.yml
@@ -5,4 +5,3 @@ rhel_pkgs: gcc,numactl-devel,bc,git,unzip,perf
 ubuntu_pkgs: libnuma-dev,gcc,unzip,zip
 amazon_pkgs: numactl,bc,git,zip,unzip
 test_script_to_run: run_pig.sh
-pre_setup: /home/dvalin/install_bc


### PR DESCRIPTION
# Description
Remove an old entry from the pig config template

# Before/After Comparison
Before: Line is in template that should not be there.
After: Line is no longer in template
No change in behavior, just removing a line no longer required, and may cause issues in the future.

# Clerical Stuff
This closes #250 

Relates to JIRA: RPOPC-550
