### PR TITLE
Provide `--no_pkg_install` to wrappers when needed

### DIFF
--- a/ansible_roles/roles/test_generic/tasks/main.yml
+++ b/ansible_roles/roles/test_generic/tasks/main.yml
@@ -79,6 +79,7 @@
         --host_config "{{ config_info.host_config_info }}"
         --sysname "{{ config_info.host_or_cloud_inst }}"
         --sys_type {{ config_info.system_type }}
+        {{ "--no_pkg_install" if config_info.do_not_install_packages else "" }}
         {{ test_data.test_specific }}
 
   - name: command running

--- a/ansible_roles/roles/test_generic/tasks/main.yml
+++ b/ansible_roles/roles/test_generic/tasks/main.yml
@@ -68,18 +68,30 @@
     command: date +"%T_%m%d%Y"
     register: time_period
 
+  - name: build the command
+    set_fact:
+      cmd_line: >
+        {{ dest_dir }}/{{ test_data.exec_dir }}/{{ test_data.test_script_to_run }}
+        --run_user {{ config_info.test_user }}
+        --home_parent {{ config_info.user_parent_home_dir }}
+        --iterations {{ config_info.test_iterations }}
+        --tuned_setting {{ sys_confg }}
+        --host_config "{{ config_info.host_config_info }}"
+        --sysname "{{ config_info.host_or_cloud_inst }}"
+        --sys_type {{ config_info.system_type }}
+        {{ test_data.test_specific }}
+
   - name: command running
     debug:
-      msg: "{{ dest_dir }}/{{ test_data.exec_dir }}/{{ test_data.test_script_to_run }} --run_user {{ config_info.test_user }} --home_parent {{ config_info.user_parent_home_dir }} --iterations {{ config_info.test_iterations }} --tuned_setting {{ sys_confg }} --host_config \"{{ config_info.host_config_info }}\" --sysname \"{{ config_info.host_or_cloud_inst }}\" --sys_type {{ config_info.system_type }} {{ test_data.test_specific }}"
+      msg: "{{ cmd_line }}"
 
-  - name: record the shell using
-    shell: "echo \"#/bin/bash\" > /tmp/{{ test_data.test_name }}.cmd"
-    
-  - name: provide the command running
-    shell: "echo \"{{ dest_dir }}//{{ test_data.exec_dir }}/{{ test_data.test_script_to_run }} --run_user {{ config_info.test_user }} --home_parent {{ config_info.user_parent_home_dir }} --iterations {{ config_info.test_iterations }} --tuned_setting {{ sys_confg }} --host_config \"{{ config_info.host_config_info }}\" --sysname \"{{ config_info.host_or_cloud_inst }}\" --sys_type {{ config_info.system_type }} {{ test_data.test_specific }}\" | sed \"s/}//g\" >> /tmp/{{ test_data.test_name }}.cmd"
-
-  - name: Make runnable
-    shell: "chmod 755 //tmp/{{ test_data.test_name }}.cmd"
+  - name: Build run script
+    copy:
+      content: |
+        #!/bin/bash
+        {{ cmd_line }}
+      dest: "/tmp/{{ test_data.test_name }}.cmd"
+      mode: "0755"
 
   - name: retrieve the command file
     fetch:


### PR DESCRIPTION
# Description
This PR adds `--no_pkg_install`  to wrappers when package installation would be skipped otherwise.

# Before/After Comparison
## Before
`./burden --no_packages` would not give `--no_pkg_install` to the running wrappers

## After
`./burden --no_packages` will give `--no_pkg_install` to the running wrapper.

# Clerical Stuff
This should fix #252

Relates to JIRA: RPOPC-551
