### PR TITLE
No longer need l_onemklbench_p_2023.2.0_49340.tgz, remove it from

### DIFF
--- a/config/linpack_template.yml
+++ b/config/linpack_template.yml
@@ -7,4 +7,4 @@ ubuntu_pkgs: unzip,zip,numactl
 amazon_pkgs: bc,git,zip,unzip
 test_script_to_run: linpack_run
 test_specific: "--interleave all --iterations 1"
-upload_extra: "/home/exports/l_onemklbench_p_2023.2.0_49340.tgz,/home/exports/xlinpack_xeon64-NEW"
+upload_extra: "/home/exports/xlinpack_xeon64-NEW"


### PR DESCRIPTION
uploads

# Description
Removes the uploads of l_onemklbench_p_2023.2.0_49340.tgz.  We no longer require it.

# Before/After Comparison
Before: File was uploaded
After: File is not uploaded.

# Clerical Stuff
This closes #254 



Relates to JIRA: RPOPC-552

# Test
Verified that linpack runs with the uploaded zip file.
