### PR TITLE
Add gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+.ansible/
+2
+
+# Ignore local configs
+local_configs/
+!local_configs/README
+!local_configs/config_samp
+
+# Ignore system locks
+lock_dir
+
+# Ignore test result files
+failed_runs
+failed_tests
+java_info
+test_info
+results_info
+utils_version
+
+# Ignore archive files
+*.tar*
+*.zip
+
+run_burden_*
+
+# Ignore most scenario files
+*scenario*
+
+#Ignore most result directories
+*/rhel/*
+*/ubuntu/*
+*/amazon/*
+
+#ignore auto-generated configs
+config/full_test_defs.yml
+config/git_vers

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ run_burden_*
 #ignore auto-generated configs
 config/full_test_defs.yml
 config/git_vers
+config/failed_test


### PR DESCRIPTION
# Description
Adds a gitignore file, excluding the following:
- Archive files (tar and zip files)
- autogenerated files within the config directory
- Most result directories identified by the following subdirectories
  - rhel
  - ubuntu
  - amazon
- Most test result files (including information about failures)
- local_config files for local systems
- .ansible directory


# Before/After Comparison
## Before
Git does not ignore any of the files listed above, which could lead to accidentally committing those files back to this repo.

## After
Git ignores all of the above files, significantly reducing the risk of accidentally commiting auto-generated files or test data.
 
# Clerical Stuff
This resolves #257 

Relates to JIRA: RPOPC-553
