### PR TITLE
Error checking added to parse_disk_line

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -1176,6 +1176,9 @@ reduce_options()
 	if [[ $option_string == *"Disk"* ]]; then
 		string=$ct_config":"$option_string
 		data=`parse_disk_line "${string}"`
+		if [[ $? -ne 0 ]]; then
+			cleanup_and_exit "Error: Invalid disk line. ${string}" 1
+		fi
 		gl_cloud_number_disks=`echo ${data} | cut -d: -f4 | bc`
 		gl_cloud_disk_type=`echo ${data} | cut -d: -f3`
 		cloud_disk_size=`echo ${data} | cut -d: -f2 | bc`
@@ -2522,6 +2525,9 @@ verify_host_config()
 		fi
 		if [[ $entry == *"Disks"* ]] && [[ $gl_disks_present == "0" ]]; then
 			gl_disks_present=`bin/parse_disk_line \"$entry\" | cut -d':' -f4`
+			if [[ $? -ne 0 ]]; then
+				cleanup_and_exit "Error: Invalid disk line. ${string}" 1
+			fi
 			if [[ $gl_disks_present == "0" ]]; then
 				if [[ $entry == *"type=internal"* ]]; then
 					gl_internal_disks=1

--- a/bin/parse_disk_line
+++ b/bin/parse_disk_line
@@ -33,7 +33,7 @@ set_disk_field()
 	elif [[ $dfield == *"throughput"* ]]; then
 		disk_tp=$value
 	else
-		echo $dfield: Unknown field, bail out.
+		echo echo "$dfield: Unknown field, bail out."
 		exit 1
 	fi
 }

--- a/bin/parse_disk_line
+++ b/bin/parse_disk_line
@@ -69,10 +69,10 @@ if [[ $ct_config == *"Disks"* ]]; then
 		fi
 		let "dindex=$dindex+1"
 		new_dfield=`echo $ct_config | cut -d';' -f${dindex}`
-		if [ -z $new_dfield ] ; then
+		if [[ -z $new_dfield ]] ; then
 			break
 		fi
-		if [ $new_dfield == $dfield ]; then
+		if [[ $new_dfield == $dfield ]]; then
 			break
 		fi
 		dfield=$new_dfield

--- a/bin/parse_disk_line
+++ b/bin/parse_disk_line
@@ -24,18 +24,17 @@ set_disk_field()
 	value=`echo ${dfield} | cut -d'=' -f 2`
 	if [[ $dfield == *"number"* ]]; then
 		number_disks=$value
-	fi
-	if [[ $dfield == *"type"* ]]; then
+	elif [[ $dfield == *"type"* ]]; then
 		disk_type=$value
-	fi
-	if [[ $dfield == *"size"* ]]; then
+	elif [[ $dfield == *"size"* ]]; then
 		disk_size=$value
-	fi
-	if [[ $dfield == *"iops"* ]]; then
+	elif [[ $dfield == *"iops"* ]]; then
 		disk_iops=$value
-	fi
-	if [[ $dfield == *"throughput"* ]]; then
+	elif [[ $dfield == *"throughput"* ]]; then
 		disk_tp=$value
+	else
+		echo $dfield: Unknown field, bail out.
+		exit 1
 	fi
 }
 
@@ -45,22 +44,29 @@ set_disk_field()
 #
 instance_type=`echo $1 | cut -d: -f1`
 fields=`echo "$1" | sed "s/&/ /g"`
-
+index=0
 for i in $fields
 do
+	let "indecx=$index+1"
 	if [[ $i == *"Disks"* ]]; then
 		ct_config=$i
+		break
 	fi
 done
 
+lookup=0
 if [[ $ct_config == *"Disks"* ]]; then
-	index=1
 	let "index=$index+1"
 	field=`echo $ct_config | cut -d: -f${index}`
 	dindex=1
 	dfield=`echo $ct_config | cut -d';' -f${dindex}`
 	while [ $dfield != "" ]; do
-		set_disk_field
+		if [[ $lookup -eq 1 ]]; then
+			set_disk_field
+		fi
+		if [[ $dfield == *"Disk"* ]]; then
+			lookup=1
+		fi
 		let "dindex=$dindex+1"
 		new_dfield=`echo $ct_config | cut -d';' -f${dindex}`
 		if [ -z $new_dfield ] ; then
@@ -75,3 +81,4 @@ else
 	instance_type=$ct_config
 fi
 echo $instance_type:$disk_size:$disk_type:$number_disks:$disk_iops:${disk_tp}
+exit 0

--- a/bin/parse_disk_line
+++ b/bin/parse_disk_line
@@ -47,7 +47,7 @@ fields=`echo "$1" | sed "s/&/ /g"`
 index=0
 for i in $fields
 do
-	let "indecx=$index+1"
+	let "index=$index+1"
 	if [[ $i == *"Disks"* ]]; then
 		ct_config=$i
 		break


### PR DESCRIPTION
# Description
Hardens parse_disk_line, so it will detect fields that wrong.

# Before/After Comparison
Before:  If throughput field name was misspelled, we would simply ignore it, and assign the default value for throughput.
After:  If we can not determine the designated field, we flag it and return a 1 for error code.  If all fields are present, we will return a 0 for a rtc.

# Clerical Stuff
This closes #259 


Relates to JIRA: RPOPC-554

# Test
1) Verified that a bad field in the string passed to parse_disk_line is caught and return code of 1 is returned.
2) Verified that a valid string passed into parse_disk_line passes properly, and rtc of 0 is returned.
3) Verified the above using burden.