### PR TITLE
Additional tags are being asked for

### DIFF
--- a/ansible_roles/roles/aws_create/files/tf/networking.tf
+++ b/ansible_roles/roles/aws_create/files/tf/networking.tf
@@ -12,6 +12,9 @@ provider "aws" {
         Environment = "${var.Environment}"
         Jirald = "${var.Jirald}"
         TicketID = "${var.TicketID}"
+        app-code = "${var.app_code}"
+        service-phase = "${var.service_phase}"
+        cost-center = "${var.cost_center}"
       }
     }
 }
@@ -28,6 +31,9 @@ resource "aws_vpc" "zathras_vpc" {
       Environment = "${var.Environment}"
       Jirald = "${var.Jirald}"
       TicketID = "${var.TicketID}"
+      app-code = "${var.app_code}"
+      service-phase = "${var.service_phase}"
+      cost-center = "${var.cost_center}"
     }
 #
 # Uncomment when using ipv6

--- a/bin/burden
+++ b/bin/burden
@@ -1518,6 +1518,9 @@ generate_tags()
   		echo "  Manager: Unknown" >> tags_defaults
   		echo "  Project: Testing" >> tags_defaults
   		echo "  Environment: Test" >> tags_defaults
+		echo "  app_code: None" >> tags_defaults
+		echo "  service_phase: None" >> tags_defaults
+		echo "  cost_center: None" >> tags_defaults
   		echo "  Jirald: ${1}" >> tags_defaults
 	fi
 	#
@@ -1560,8 +1563,14 @@ generate_tags()
   		echo "  type = string" >> add_vars_tf
   		echo "  default = \"none\"" >> add_vars_tf
 		echo "}" >> add_vars_tf
+		if [[ $gl_system_type == "azure" ]]; then
+			val1=`echo $value | sed "s/_/-/g"`
+			echo $value $val1 >> /tmp/dave
+		else
+			val1=$value
+		fi
 		echo "${value} = \"{{ config_info.${value} }}\"" >> add_main_tf_vars
-		echo "${indent}${value} = \"\${var.${value}}\"" >> add_main_vars.tf
+		echo "${indent}${val1} = \"\${var.${value}}\"" >> add_main_vars.tf
 		#
 		# Terraform spot does not set the tags, build a tag list (AWS only)
 		#

--- a/config/tags.conf
+++ b/config/tags.conf
@@ -5,3 +5,6 @@
   Environment: Test
   Jirald: Your name
   TicketID: #
+  app_code: cost center
+  service_phase: phase
+  cost_center: cc


### PR DESCRIPTION
# Description
Adds the following tags, to meet tracking requirements
app_code: 
service_phase: 
cost_center: 

# Before/After Comparison
Before:  New tags not present
After: New tags are present.

# Clerical Stuff
This closes #267 

Relates to JIRA: RPOPC-558

# Testing
Verified the tags appeared on AWS systems (has a bit of a different path than gcp/azure).
Verified the tags appeared on an Azure system.  GCP has the exact same logic/code.
Does not impact bare metal systems, but verified bare metal still worked.