### PR TITLE
Add iozone test back.

### DIFF
--- a/config/iozone_template.yml
+++ b/config/iozone_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/iozone-wrapper/archive/refs/tags
-exec_dir: "iozone-wrapper-1.21/iozone"
-repo_file: "v1.21.zip"
+exec_dir: "iozone-wrapper-1.22/iozone"
+repo_file: "v1.22.zip"
 rhel_pkgs: gcc,bc,wget,perl-Math-BigInt.noarch,perl-Math-BigRat.noarch,perl-Math-Complex.noarch,perf,git,unzip
 ubuntu_pkgs: gcc
 amazon_pkgs: gcc

--- a/config/test_defs.yml
+++ b/config/test_defs.yml
@@ -116,3 +116,9 @@ test_defs:
     test_name: pyperf
     test_description: pyperfotmance test
     archive_results: "yes"
+
+  test18:
+    test_template: iozone_template.yml
+    test_name: iozone
+    test_description: iozone
+    test_specific: "--devices_to_use {{ dyn_data.storage }} --filesys xfs,ext4,ext3 --all_test --mount_location /iozone/iozone0 --eatmem --auto"


### PR DESCRIPTION
# Description
Adds the iozone test back to the config.

# Before/After Comparison
Before: iozone test was not recognized.
After: iozone test is recognized.

# Clerical Stuff
This closes #274 

Relates to JIRA: RPOPC-580