### PR TITLE
Fix versioning so we do not include pre-releases as the latest version

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -51,6 +51,8 @@ else
 fi
 
 # check for and install system packages
+# We expect EPEL to be installed, which contains gh.
+#
 packages=(ansible-core git jq python python3-pip terraform unzip wget)
 
 for package in "${packages[@]}"; do 

--- a/bin/utils/test_versions_ops
+++ b/bin/utils/test_versions_ops
@@ -67,7 +67,8 @@ test_version_ops()
 		location=`grep location: ${test_repo} | cut -d: -f2- | sed "s/ //g"`
 		if [[ $location == "https://github.com"* ]]; then
 			repo=`echo $location | cut -d'/' -f 1-5`
-			git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags $repo | rev | cut -d'/' -f1 | rev >  git_vers
+			gh release list  --repo $repo | rev | awk '{print $1" "$2" "$3}' | rev > vers_file
+			cut -d' ' -f 2 vers_file > git_vers
 			#
 			# Make sure the tag we want is present
 			#
@@ -77,7 +78,10 @@ test_version_ops()
 				version_fail="$repo, version $using_version is not defined."
 				bail_out=1
 			fi
-			latest=`tail -1 git_vers`
+			#
+			# Now obtain the latest official version
+			#
+			latest=`grep "^Latest" vers_file | cut -d' ' -f 2`
 			if [[ $using_version != $latest ]]; then
 				version_ok="no"
 			else

--- a/bin/utils/test_versions_ops
+++ b/bin/utils/test_versions_ops
@@ -71,6 +71,9 @@ test_version_ops()
 			# Make sure the tag we want is present
 			#
 			version_fail=""
+			#
+			# We expect EPEL to be installed, which contains gh.
+			#
 			gh release view -R $repo $using_version --json tagName -q .tagName &> /dev/null
 			if [ $? -ne 0 ]; then
 				version_fail="$repo, version $using_version is not defined."

--- a/bin/utils/test_versions_ops
+++ b/bin/utils/test_versions_ops
@@ -67,13 +67,11 @@ test_version_ops()
 		location=`grep location: ${test_repo} | cut -d: -f2- | sed "s/ //g"`
 		if [[ $location == "https://github.com"* ]]; then
 			repo=`echo $location | cut -d'/' -f 1-5`
-			gh release list  --repo $repo | rev | awk '{print $1" "$2" "$3}' | rev > vers_file
-			cut -d' ' -f 2 vers_file > git_vers
 			#
 			# Make sure the tag we want is present
 			#
 			version_fail=""
-			grep ${using_version} git_vers > /dev/null
+			gh release view -R $repo $using_version --json tagName -q .tagName &> /dev/null
 			if [ $? -ne 0 ]; then
 				version_fail="$repo, version $using_version is not defined."
 				bail_out=1
@@ -81,7 +79,7 @@ test_version_ops()
 			#
 			# Now obtain the latest official version
 			#
-			latest=`grep "^Latest" vers_file | cut -d' ' -f 2`
+			latest=`gh release view -R $repo --json tagName -q .tagName`
 			if [[ $using_version != $latest ]]; then
 				version_ok="no"
 			else


### PR DESCRIPTION
# Description
Prevents pulling in pre-releases when we have asked to update the test versions

# Before/After Comparison
Before: We could pull in a pre-release version as an official version.
After: We will pull in the version that is marked as the latest.

# Clerical Stuff
This closes #276 

Relates to JIRA: RPOPC-584

# Testing
Verified the pre-release versions do not turn up.
Verified still can use a pre-release version.
Verfiied when updating the versions, the pre-release versions are not considered.
