### PR TITLE
Cleaning up around rm command

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -781,7 +781,7 @@ create_test_run_file()
 			test_name_ret=$(grab_a_field "${line}" ":" 2)
 			lcl_test_name=`echo $test_name_ret | sed "s/ //g"`
 			if [[ $lcl_test_name == $look_for ]]; then
-				rm tests_to_run/$1.yml 2> /dev/null
+				rm -f tests_to_run/$1.yml
 				echo "---" >> tests_to_run/$1.yml
 				echo $line >> tests_to_run/$1.yml
 				found=1
@@ -986,22 +986,22 @@ check_for_dup_config_entries()
 	entries_check=`mktemp /tmp/zathras_dup_check.XXXXX`
 	grep "${1}:" ${gl_top_dir}/local_configs/${gl_host_config_info}.config > $entries_check
 	if [[ $? -ne 0 ]]; then
-		rm $entries_check 2> /dev/null
+		rm -f $entries_check
 		cleanup_and_exit "Error: No ${1} entry in ${gl_top_dir}/local_configs/${gl_host_config_info}.config" 1
 	fi
 
 	field_option=`awk '{print $2}' $entries_check`
 	if [[ $field_option == "" ]]; then
-		rm $entries_check 2> /dev/null
+		rm -f $entries_check
 		cleanup_and_exit "Error: Field  ${1} is present, but has no entries, ${gl_top_dir}/local_configs/${gl_host_config_info}.config" 1
 	fi
 
 	numb_entries=`uniq -c $entries_check | awk '{print $1}'`
 	if [[ $numb_entries -gt 1 ]]; then
-		rm $entries_check 2> /dev/null
+		rm -f $entries_check
 		cleanup_and_exit "Error: Duplicate ${1} entries in ${gl_top_dir}/local_configs/${gl_host_config_info}.config" 1
 	fi
-	rm $entries_check 2> /dev/null
+	rm -f $entries_check
 }
 
 #
@@ -3160,7 +3160,7 @@ integrate_templates()
 	gl_test_def_dir=`echo $1 | cut -d'/' -f 1-${chars}`
 
 	if [[ $gl_first_invocation -eq 1 ]]; then
-		rm $gl_test_def_dir/full_test_defs.yml 2> /dev/null
+		rm -f $gl_test_def_dir/full_test_defs.yml
 	fi
 	if [[ ! -f $gl_test_def_dir/full_test_defs.yml ]]; then
 		while IFS= read -r line
@@ -3195,8 +3195,8 @@ integrate_templates()
 		#
 		verify_test_configuration $gl_test_def_dir/full_test_defs.yml $1 1
 	fi
-	rm $temp_def 2> /dev/null
-	rm $tmpfile 2> /dev/null
+	rm -f $temp_def
+	rm -f $tmpfile
 }
 
 #
@@ -3940,7 +3940,7 @@ add_missing_test()
 		if [[ $test_info == "  system"* ]];then
 			if [ $test_section_start -eq 1 ]; then
 				check_for_test  $system "$test" $new_scen_file
-				rm new_info 2> /dev/null
+				rm -f new_info
 			fi
 			test_section_start=1
 			continue
@@ -3949,7 +3949,7 @@ add_missing_test()
 	done < $scenario_file
 	if [[ -f new_info ]]; then
 		check_for_test  $system "$test" $new_scen_file
-		rm new_info 2> /dev/null
+		rm -f new_info
 	fi
 }
 
@@ -3962,7 +3962,7 @@ handle_error_reruns()
 	sed "s/+++/\//g" ${gl_top_dir}/${gl_scenario_to_run} > $scenario_to_run
 
 	new_scen_file=${scenario_to_run}_rerun
-	rm $new_scen_file 2> /dev/null
+	rm -f $new_scen_file
 	gl_sys_index_rerun=1
 
 	#

--- a/bin/burden
+++ b/bin/burden
@@ -601,7 +601,7 @@ show_test_version()
 		retrieve_versions $test_name
 		cd ..
 	done
-	rm -rf tests_to_run 2> /dev/null
+	rm -rf tests_to_run
 	cleanup_and_exit "" 0
 }
 
@@ -859,7 +859,7 @@ general_setup()
 {
 	hostdir=`pwd`/ssh_known_hosts
 	running_dir=`pwd`
-	rm -rf $hostdir 2> /dev/null
+	rm -rf $hostdir
 	make_dir_report_errors $hostdir
 	#
 	# Replace test_defs.yml with full_test_defs.yml.
@@ -2125,7 +2125,7 @@ create_ansible_options()
 			#
 			# We do not want ssh perm files there.
 			#
-			rm -rf $gl_archive_location/$direct/config 2> /dev/null
+			rm -rf $gl_archive_location/$direct/config
 		fi
 		rm -rf results_info tests*
 		popd > /dev/null
@@ -4086,7 +4086,7 @@ first_invocation()
 				#
 				# Pulling from git
 				#
-				rm -rf config_git 2> /dev/null
+				rm -rf config_git
 				timeout $gl_git_timeout git clone ${git_area} config_git 2> /dev/null
 				if [[ $? -ne  0 ]]; then
 					cleanup_and_exit "\nError: retrieval of git repo $git_area has failed." 1
@@ -4212,7 +4212,7 @@ if [[ "${gl_scenario_to_run}" == *"https:"* ]] || [[ "${gl_scenario_to_run}" == 
 	#
 	# Pulling from git
 	#
-	rm -rf scenarios 2> /dev/null
+	rm -rf scenarios
 	timeout $gl_git_timeout git clone ${git_area} scenarios 2> /dev/null
 	if [[ $? -ne  0 ]]; then
 		cleanup_and_exit "\nError: retrieval of git repo $git_area has failed." 1

--- a/bin/burden
+++ b/bin/burden
@@ -960,7 +960,7 @@ remove_hostnames_added()
 {
 	if [[ $gl_system_type != "local" ]]; then
 		cd $hostdir
-		ssh_files_to_remove=`ls remove_from_ssh_* 2> /dev/null`k
+		ssh_files_to_remove=`ls remove_from_ssh_* 2> /dev/null`
 		if [ $? -eq 0 ]; then
 			for rm_ssh_file in $ssh_files_to_remove;
 			do


### PR DESCRIPTION
# Description
Removes redirects for rm's by using rm -f
Removes extranous letter on line ssh_files_to_remove=`ls remove_from_ssh_* 2> /dev/null`k
Removes redirects on existing lines with rm -f


# Before/After Comparison
Before: Extra code around removes, as well as getting wrong file name.
After: Extraneous  code removed, now get the right file name.

# Clerical Stuff
This closes #280 

Relates to JIRA: RPOPC-590
