### PR TITLE
Update hammerdb config to contain the uploads location

### DIFF
--- a/config/hammerdb_template.yml
+++ b/config/hammerdb_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/hammerdb-wrapper/archive/refs/tags
-exec_dir: "hammerdb-wrapper-1.16/hammerdb"
-repo_file: "v1.16.zip"
+exec_dir: "hammerdb-wrapper-1.19/hammerdb"
+repo_file: "v1.19.zip"
 os_supported: all
 rhel_pkgs_9: lvm2,sysstat,tar,bc,nvme-cli,perf,git,unzip
 rhel_pkgs: lvm2,sysstat,tar,bc,perf,git,unzip
@@ -8,3 +8,4 @@ ubuntu_pkgs: unzip,zip
 amazon_pkgs: none
 storage_required: "yes"
 test_script_to_run: hammerdb
+upload_extra: "/home/exports/hammerdb-tpcc.tar"


### PR DESCRIPTION
# Description
Adds upload information to the hammerdb config.

# Before/After Comparison
Before: Fails as we do not have the upload location for the kit.
After: passes.
# Clerical Stuff
This closes #286 


Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-603
