### PR TITLE
Fix it so the private network stays with ubuntu.

### DIFF
--- a/ansible_roles/roles/ssh_key_exchange/tasks/main.yml
+++ b/ansible_roles/roles/ssh_key_exchange/tasks/main.yml
@@ -1,4 +1,30 @@
 ---
+#
+# Ubuntu is a bit of a pain with netplan.  Issue ifconfig here in hopes
+# of having the ip stick.
+#
+- name: ubuntu net config
+  block:
+  - name: make sure ifconfig is installed on host 0
+    delegate_to: "{{ ip_list[0] }}"
+    become: yes
+    shell: "apt -y install net-tools"
+  - name: make sure ifconfig is installed on host 1
+    delegate_to: "{{ ip_list[1] }}"
+    become: yes
+    shell: "apt -y install net-tools"
+
+  - name: ifconfig host 0
+    delegate_to: "{{ ip_list[0] }}"
+    become: yes
+    shell: "ifconfig ens6 10.0.25.100 netmask 255.255.255.0"
+
+  - name: ifconfig host 1
+    delegate_to: "{{ ip_list[1] }}"
+    become: yes
+    shell: "ifconfig ens6 10.0.25.101 netmask 255.255.255.0"
+  when: config_info.os_vendor == "ubuntu"
+
 # tasks file for roles/ssh_key_exchange
 - name: SSH KeyGen command
   delegate_to: "{{ item }}"
@@ -61,15 +87,20 @@
   with_items:
     - "{{ ip_list }}"
 
-
+#
+# If we restart the sshd service with ubuntu, we lose connectivty.
+#
 - name: restart sshd service
-  delegate_to: "{{ item }}"
-  become: yes
-  systemd:
-    name: sshd
-    state: restarted
-  with_items:
-    - "{{ ip_list }}"
+  block:
+  - name:  restart sshd service if not ubuntu.
+    delegate_to: "{{ item }}"
+    become: yes
+    systemd:
+      name: sshd
+      state: restarted
+    with_items:
+      - "{{ ip_list }}"
+  when: config_info.os_vendor != "ubuntu"
 
 - name: Make sure we can ssh in to net1 from net2
   delegate_to: "{{ ip_list[1] }}"

--- a/ansible_roles/roles/ssh_key_exchange/tasks/main.yml
+++ b/ansible_roles/roles/ssh_key_exchange/tasks/main.yml
@@ -3,28 +3,39 @@
 # Ubuntu is a bit of a pain with netplan.  Issue ifconfig here in hopes
 # of having the ip stick.
 #
-- name: ubuntu net config
+
+- name: Ubuntu net config
   block:
-  - name: make sure ifconfig is installed on host 0
+  - name: Ensure net-tools is installed host 0
     delegate_to: "{{ ip_list[0] }}"
     become: yes
-    shell: "apt -y install net-tools"
-  - name: make sure ifconfig is installed on host 1
+    apt:
+      name: net-tools
+      state: present
+  - name: Ensure net-tools is installed host 1
     delegate_to: "{{ ip_list[1] }}"
     become: yes
-    shell: "apt -y install net-tools"
+    apt:
+      name: net-tools
+      state: present
 
+  #
+  # Get the network interface, and then assign the ip to it.
+  # Notes
+  # 
+  # Assumption is only one unconfigured network
   - name: ifconfig host 0
     delegate_to: "{{ ip_list[0] }}"
     become: yes
-    shell: "ifconfig ens6 10.0.25.100 netmask 255.255.255.0"
+    shell: "ifconfig `ifconfig -a | grep flags | grep -v UP | cut -d: -f1` 10.0.25.100 netmask 255.255.255.0"
 
   - name: ifconfig host 1
     delegate_to: "{{ ip_list[1] }}"
     become: yes
-    shell: "ifconfig ens6 10.0.25.101 netmask 255.255.255.0"
+    shell: "ifconfig `ifconfig -a | grep flags | grep -v UP | cut -d: -f1` 10.0.25.101 netmask 255.255.255.0"
   when: config_info.os_vendor == "ubuntu"
 
+  # tasks file for roles/ssh_key_exchange
 # tasks file for roles/ssh_key_exchange
 - name: SSH KeyGen command
   delegate_to: "{{ item }}"


### PR DESCRIPTION
# Description
Fixes it so the private network ip is present when we run uperf.

# Before/After Comparison
Before:  Due to the reboot, and restarting ssh we lose the ipv4 private ip address.
After:  Address is present.

# Clerical Stuff
This closes #288 


Relates to JIRA: RPOPC-636
