### PR TITLE
Fix it so azure does not run uperf on both systems.

### DIFF
--- a/ansible_roles/roles/azure_create/tasks/add_host_to_groups.yml
+++ b/ansible_roles/roles/azure_create/tasks/add_host_to_groups.yml
@@ -3,11 +3,9 @@
 
 - name: set_test_host
   add_host:
-    name: "{{ item }}"
+    name: "{{ public_ip_address[0] }}"
     groups: test_group
     ansible_user: "{{ config_info.test_user }}"
-  with_items:
-    - "{{ public_ip_address }}"
 
 - name: now add it to the test_group file
   include_role:


### PR DESCRIPTION
# Description
Fixes it so we are not running uperf on both client/server in the azure environment.

# Before/After Comparison
Before: When using azure, uperf is being executed on both the client and server.
# Clerical Stuff
This closes #290 

Relates to JIRA: RPOPC-637
