### PR TITLE
Add missing ansible galaxy collections

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -115,7 +115,7 @@ done
 
 
 # install AWS collection and POSIX collection for ansible
-ansible_collections=(amazon.aws ansible.posix community.aws)
+ansible_collections=(amazon.aws ansible.posix community.aws community.general)
 for collection in "${ansible_collections[@]}"; do
         ansible-galaxy collection install "$collection" || {
                 exit 1

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -115,7 +115,7 @@ done
 
 
 # install AWS collection and POSIX collection for ansible
-ansible_collections=(amazon.aws ansible.posix)
+ansible_collections=(amazon.aws ansible.posix community.aws)
 for collection in "${ansible_collections[@]}"; do
         ansible-galaxy collection install "$collection" || {
                 exit 1


### PR DESCRIPTION
# Description
This PR adds two missing collections to the list of Ansible Galaxy collections included in the Zathras install script:
- community.aws provides required functionality for AWS;
- community.general provides required functionality for SUSE;

# Before/After Comparison
## Before
```
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/amazon-aws-10.1.1.tar.gz to /home/tester/.ansible/tmp/ansible-local-6689wmz1ggge/tmpjbge68ds/amazon-aws-10.1.1-001xup2c
Installing 'amazon.aws:10.1.1' to '/home/tester/.ansible/collections/ansible_collections/amazon/aws'
amazon.aws:10.1.1 was installed successfully
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/ansible-posix-2.1.0.tar.gz to /home/tester/.ansible/tmp/ansible-local-6697nwb5srwy/tmp9tpl2big/ansible-posix-2.1.0-lr9mk4ve
Installing 'ansible.posix:2.1.0' to '/home/tester/.ansible/collections/ansible_collections/ansible/posix'
ansible.posix:2.1.0 was installed successfully
```
##After 
```
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/amazon-aws-10.1.1.tar.gz to /home/tester/.ansible/tmp/ansible-local-6689wmz1ggge/tmpjbge68ds/amazon-aws-10.1.1-001xup2c
Installing 'amazon.aws:10.1.1' to '/home/tester/.ansible/collections/ansible_collections/amazon/aws'
amazon.aws:10.1.1 was installed successfully
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/ansible-posix-2.1.0.tar.gz to /home/tester/.ansible/tmp/ansible-local-6697nwb5srwy/tmp9tpl2big/ansible-posix-2.1.0-lr9mk4ve
Installing 'ansible.posix:2.1.0' to '/home/tester/.ansible/collections/ansible_collections/ansible/posix'
ansible.posix:2.1.0 was installed successfully
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/community-aws-10.0.0.tar.gz to /home/tester/.ansible/tmp/ansible-local-6701ck7l_qd8/tmp3zdz9hej/community-aws-10.0.0-w0fsgerg
Installing 'community.aws:10.0.0' to '/home/tester/.ansible/collections/ansible_collections/community/aws'
community.aws:10.0.0 was installed successfully
'amazon.aws:10.1.1' is already installed, skipping.
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/artifacts/community-general-11.4.0.tar.gz to /home/tester/.ansible/tmp/ansible-local-6705zz38dqas/tmpgzokv08k/community-general-11.4.0-r5ijfrnk
Installing 'community.general:11.4.0' to '/home/tester/.ansible/collections/ansible_collections/community/general'
community.general:11.4.0 was installed successfully
```

# Clerical Stuff
This closes #292 
This closes #293 

Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-641
Relates to JIRA: RPOPC-642
