### PR TITLE
Remove check for python3.

### DIFF
--- a/ansible_roles/roles/aws_create/tasks/aws_instance_create.yml
+++ b/ansible_roles/roles/aws_create/tasks/aws_instance_create.yml
@@ -198,28 +198,3 @@
       line: "aws_net_instance_id: none"
   when: config_info.cloud_numb_networks == 0
 
-- name: Make sure python3 is installed
-  become: no
-  local_action: shell ssh -q -oStrictHostKeyChecking=no -i {{ config_info.ssh_key }} {{ config_info.test_user }}@{{ aws_tf_info.public_dns_host0 }} sudo yum install -y python3
-  when: config_info.os_vendor == "rhel"
-
-- name: Make sure python3 is installed
-  become: no
-  local_action: shell ssh -q -oStrictHostKeyChecking=no -i {{ config_info.ssh_key }} {{ config_info.test_user }}@{{ aws_tf_info.public_dns_host1 }} sudo yum install -y python3
-  when:
-   - config_info.cloud_numb_networks != 0
-   - config_info.os_vendor == "rhel"
-
-- name: Make sure python3 is installed
-  become: no
-  local_action: shell ssh -q -oStrictHostKeyChecking=no -i {{ config_info.ssh_key }} {{ config_info.test_user }}@{{ aws_tf_info.public_dns_host0 }} sudo yum install -y python38
-  when:
-   - config_info.cloud_numb_networks == 0
-   - config_info.os_vendor == "amazon"
-
-- name: Make sure python3 is installed
-  become: no
-  local_action: shell ssh -q -oStrictHostKeyChecking=no -i {{ config_info.ssh_key }} {{ config_info.test_user }}@{{ aws_tf_info.public_dns_host1 }} sudo yum install -y python38
-  when:
-   - config_info.cloud_numb_networks != 0
-   - config_info.os_vendor == "amazon"

--- a/ansible_roles/roles/azure_create/files/tf/vars.tf
+++ b/ansible_roles/roles/azure_create/files/tf/vars.tf
@@ -49,7 +49,7 @@ variable "ssh_key_path" {
 
 variable "vm_image" {
   type    = string
-  default = "RedHat:RHEL:8_4:8.4.2021081003"
+  default = "none"
 }
 
 variable "az_subscription" {


### PR DESCRIPTION
# Description
Removes the check for python3 when creating aws systems

# Before/After Comparison
Before:  Check to see if python is installed, if not bail.  This check dates back to when we started original cloud work, and python may not be installed.  Python is installed now on the initial bringup and we are failing at times because we are checking for a specific python.
After: Check is no longer done.
# Clerical Stuff
This closes #296 

Relates to JIRA: RPOPC-643
