### PR TITLE
Replace zip from git with tar.gz

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -114,6 +114,7 @@ gl_retry_failed_tests=1
 gl_base_cost=0
 gl_host_uses_nvme=0
 gl_cloud_net_type="default"
+gl_version_check_only=0
 #
 # We will default to eastus
 #
@@ -3061,6 +3062,9 @@ verify_test_configuration()
 	if [ $bail_out -eq 1 ]; then
 		cleanup_and_exit "Error: At least one get tag is not known." 1
 	fi
+	if [[ $gl_version_check_only -eq 1 ]]; then
+		cleanup_and_exit "" 0
+	fi
 }
 #
 # We read in the template file for the test, and for each line that is not
@@ -3685,6 +3689,7 @@ set_general_value()
 			shift_by=2
 		;;
 		--test_version_check)
+			gl_version_check_only=1
 			shift_by=1
 		;;
 		--test_user)

--- a/bin/utils/test_versions_ops
+++ b/bin/utils/test_versions_ops
@@ -63,7 +63,7 @@ test_version_ops()
 	   	   [[ $test_repo = "verify.yml" ]]; then
 			continue;
 		fi
-		using_version=`grep repo_file $test_repo | cut -d':' -f2 | sed "s/.zip//g" |cut -d'"' -f2`
+		using_version=`grep repo_file $test_repo | cut -d':' -f2 | sed "s/.tar.gz//g" |cut -d'"' -f2`
 		location=`grep location: ${test_repo} | cut -d: -f2- | sed "s/ //g"`
 		if [[ $location == "https://github.com"* ]]; then
 			repo=`echo $location | cut -d'/' -f 1-5`

--- a/config/autohpl.yml
+++ b/config/autohpl.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/autohpl-wrapper/archive/refs/tags
 exec_dir: "autohpl-wrapper-2.0/auto_hpl"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 rhel_pkgs: gcc,make,gcc-gfortran,openblas-openmp,openmpi,openmpi-devel,wget,bc,perf,git,unzip
 ubuntu_pkgs: gcc,make,g++,python3-pip,mpi,libopenblas-base,mpi-default-bin,mpi-default-dev,mpi-specs,libmkl-intel-thread,libmkl-intel-ilp64,libmkl-intel-lp64,libmkl-core,libmkl-gnu-thread,zip,unzip
 amazon_pkgs: git,gcc,make,gcc-gfortran,blas,openmpi,openmpi-devel,wget,bc,zip,unzip

--- a/config/burst_io.yml
+++ b/config/burst_io.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/io_burst-wrapper/archive/refs/tags
 exec_dir: "io_burst-wrapper-2.0/io_burst"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 test_grouping: iozone
 rhel_pkgs: gcc,bc,wget,git,unzip,perf
 ubuntu_pkgs: gcc

--- a/config/coremark_pro_template.yml
+++ b/config/coremark_pro_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/coremark_pro-wrapper/archive/refs/tags
 exec_dir: "coremark_pro-wrapper-2.0/coremark_pro"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 rhel_pkgs: bc,numactl,perf,git,unzip,perf
 ubuntu_pkgs: unzip,zip
 amazon_pkgs: bc,git,zip,unzip

--- a/config/coremark_template.yml
+++ b/config/coremark_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/coremark-wrapper/archive/refs/tags
 exec_dir: "coremark-wrapper-2.0/coremark"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 rhel_pkgs: bc,numactl,perf,git,unzip
 ubuntu_pkgs: unzip,zip
 amazon_pkgs: bc,git,zip,unzip

--- a/config/fio_template.yml
+++ b/config/fio_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/fio-wrapper/archive/refs/tags
 exec_dir: "fio-wrapper-2.0/fio"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 rhel_pkgs: gcc,numactl,python3,bc,fio,perf,git,unzip
 ubuntu_pkgs: fio,unzip,zip
 amazon_pkgs: fio,bc,git,zip,unzip

--- a/config/hammerdb_template.yml
+++ b/config/hammerdb_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/hammerdb-wrapper/archive/refs/tags
 exec_dir: "hammerdb-wrapper-2.0/hammerdb"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 os_supported: all
 rhel_pkgs_9: lvm2,sysstat,tar,bc,nvme-cli,perf,git,unzip
 rhel_pkgs: lvm2,sysstat,tar,bc,perf,git,unzip

--- a/config/iozone_template.yml
+++ b/config/iozone_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/iozone-wrapper/archive/refs/tags
 exec_dir: "iozone-wrapper-2.0/iozone"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 rhel_pkgs: gcc,bc,wget,perl-Math-BigInt.noarch,perl-Math-BigRat.noarch,perl-Math-Complex.noarch,perf,git,unzip
 ubuntu_pkgs: gcc
 amazon_pkgs: gcc

--- a/config/linpack_template.yml
+++ b/config/linpack_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/linpack-wrapper/archive/refs/tags
 exec_dir: "linpack-wrapper-3.0/linpack"
-repo_file: "v3.0.zip"
+repo_file: "v3.0.tar.gz"
 os_supported: all
 rhel_pkgs: bc,numactl,perf,git,unzip
 ubuntu_pkgs: unzip,zip,numactl

--- a/config/passmark_template.yml
+++ b/config/passmark_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/passmark-wrapper/archive/refs/tags
 exec_dir: "passmark-wrapper-2.0/passmark"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 rhel_pkgs: bc,numactl,perf,git,unzip
 ubuntu_pkgs: unzip,zip
 amazon_pkgs: bc,git,zip,unzip

--- a/config/phoronix_template.yml
+++ b/config/phoronix_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/phoronix-wrapper/archive/refs/tags
 exec_dir: "phoronix-wrapper-3.0/phoronix"
-repo_file: "v3.0.zip"
+repo_file: "v3.0.tar.gz"
 rhel_pkgs: gcc,graphviz,python3,lksctp-tools-devel,php-cli,php-xml,php-json,bc,perf,git,unzip
 ubuntu_pkgs: zip,gcc,graphviz,python3,php-cli,php-xml,php-json,unzip,bc
 amazon_pkgs: git build-essential,gcc,graphviz,python3,bc,git,zip,unzip,php-cli,php-xml

--- a/config/pig_template.yml
+++ b/config/pig_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/pig-wrapper/archive/refs/tags
 exec_dir: "pig-wrapper-2.0/pig"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 rhel_pkgs: gcc,numactl-devel,bc,git,unzip,perf
 ubuntu_pkgs: libnuma-dev,gcc,unzip,zip
 amazon_pkgs: numactl,bc,git,zip,unzip

--- a/config/pyperformance_template.yml
+++ b/config/pyperformance_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/pyperf-wrapper/archive/refs/tags
 exec_dir: "pyperf-wrapper-2.0/pyperf"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 rhel_pkgs: bc,numactl,perf,pip,python3-devel,git,unzip,wget
 ubuntu_pkgs: unzip,zip,,python3-dev
 amazon_pkgs: bc,git,zip,unzip

--- a/config/reboot_measure.yml
+++ b/config/reboot_measure.yml
@@ -1,5 +1,5 @@
 location: https://github.com/redhat-performance/reboot_measurement/archive/refs/tags
 exec_dir: "reboot_measurement-1.6/reboot_measurement"
-repo_file: "v1.6.zip"
+repo_file: "v1.6.tar.gz"
 os_supported: all
 test_script_to_run: run_reboot.sh

--- a/config/speccpu2017_template.yml
+++ b/config/speccpu2017_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/speccpu2017-wrapper/archive/refs/tags
 exec_dir: "speccpu2017-wrapper-2.0/speccpu2017"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 rhel_pkgs_9: bc,libnsl,gcc-gfortran,nvme-cli,perf,libxcrypt-compat,git,unzip
 rhel_pkgs: bc,libnsl,gcc-gfortran,perf,git,unzip,libxcrypt-compat
 ubuntu_pkgs: gcc,bc,gfortran,g++,unzip,zip

--- a/config/specjbb_template.yml
+++ b/config/specjbb_template.yml
@@ -1,5 +1,5 @@
 location: https://github.com/redhat-performance/specjbb-wrapper/archive/refs/tags
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 exec_dir: "specjbb-wrapper-2.0/specjbb"
 rhel_pkgs: bc,numactl,perf,git,unzip
 ubuntu_pkgs: libnuma-dev,unzip,zip

--- a/config/streams_template.yml
+++ b/config/streams_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/streams-wrapper/archive/refs/tags
 exec_dir: "streams-wrapper-2.0/streams"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 os_supported: all
 rhel_pkgs: gcc,bc,perf,git,unzip,numactl
 ubuntu_pkgs: gcc,build-essential,libnuma-dev,zip,unzip

--- a/config/uperf_template.yml
+++ b/config/uperf_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/uperf-wrapper/archive/refs/tags
 exec_dir: "uperf-wrapper-2.0/uperf"
-repo_file: "v2.0.zip"
+repo_file: "v2.0.tar.gz"
 rhel_pkgs: python3,gcc,lksctp-tools-devel,bc,perf,git,unzip,perf
 ubuntu_pkgs: gcc,python3,libsctp-dev,lksctp-tools,libusrsctp-dev,make,net-tools,dh-autoreconf,zip,unzip
 amazon_pkgs: git,python3,gcc,lksctp-tools-devel,xorg-x11-xauth

--- a/docs/test_config_files.md
+++ b/docs/test_config_files.md
@@ -102,7 +102,7 @@ we drop everything but streams-wrapper and use "streams-wrapper"
 
 **test_run_from**: Some tests need to run from the local system, not the cloud system (boot timing test is one example). If local is specified, the test will run locally, if remote is specified the test will run on the test system.
 
-**repo_file**: The archive file to be downloaded. In the case of git repos, it will be <tag>.zip
+**repo_file**: The archive file to be downloaded. In the case of git repos, it will be <tag>.tar.gz
 
 **rhel_pkgs**: RHEL packages that are required to run the test; “none” if there aren’t any packaging requirements
 
@@ -135,7 +135,7 @@ we drop everything but streams-wrapper and use "streams-wrapper"
         reboot_system: "no"
         test_run_from: "remote"
         os_supported: all
-        repo_file: "v1.0.zip"
+        repo_file: "v1.0.tar.gz"
     rhel_pkgs: gcc,bc
     ubuntu_pkgs: gcc,build-essential,libnuma-dev,zip,unzip
     amazon_pkgs: gcc,bc,git,unzip,zip


### PR DESCRIPTION
# Description
Having issues with some linux derivatives not having zip present, and will cause a chicken egg issue with the packaging changes coming.  This switches to use tar.gz,  all derivatives of linux tried on, are happy.

# Before/After Comparison
Before: Zathras would fail on some flavors of linux if unzip package was not brought in
After: Zathras is happy with all flavors now, unzip package is not required.

# Clerical Stuff
This closes #302 

Relates to JIRA: RPOPC-659
