### PR TITLE
Add documentation check section to PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,9 @@ What does this PR do?  Give a short summary
 Give some examples of the before/after behavior
 of the program.
 
+# Documentation Check
+Does this change require any updates to user-facing or internal documentation?
+
 # Clerical Stuff
 Mention the issue this PR works toward resolving.  If the 
 PR completely solves the issue, use "This closes #x"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@ of the program.
 
 # Documentation Check
 Does this change require any updates to user-facing or internal documentation?
+If "yes", were those updates made?
 
 # Clerical Stuff
 Mention the issue this PR works toward resolving.  If the 


### PR DESCRIPTION
# Description
This PR adds a documentation check section to the PR template. The section asks if documentation changes are needed because of the PR, and if so, whether those changes were included. This change will help prompt contributors to keep the Zathras project documentation up to date while adding minimal overhead.

# Before/After Comparison
Before, the PR template included sections "Description", "Before/After Comparison", and "Clerical Stuff".
After, the PR template would include sections "Description", "Before/After Comparison", "Documentation Check", and "Clerical Stuff".

# Clerical Stuff
This closes #306 

Relates to JIRA: RPOPC-663
