### PR TITLE
Add the option to Zathras to turn on and off pcp in the wrappers. 

### DIFF
--- a/ansible_roles/roles/test_generic/tasks/main.yml
+++ b/ansible_roles/roles/test_generic/tasks/main.yml
@@ -80,7 +80,7 @@
         --sysname "{{ config_info.host_or_cloud_inst }}"
         --sys_type {{ config_info.system_type }}
         {{ "--no_pkg_install" if config_info.do_not_install_packages else "" }}
-        {{ config_info.pcp_state }}
+        {{ config_info.use_pcp }}
         {{ test_data.test_specific }}
 
   - name: command running

--- a/ansible_roles/roles/test_generic/tasks/main.yml
+++ b/ansible_roles/roles/test_generic/tasks/main.yml
@@ -80,6 +80,7 @@
         --sysname "{{ config_info.host_or_cloud_inst }}"
         --sys_type {{ config_info.system_type }}
         {{ "--no_pkg_install" if config_info.do_not_install_packages else "" }}
+        {{ config_info.pcp_state }}
         {{ test_data.test_specific }}
 
   - name: command running

--- a/bin/burden
+++ b/bin/burden
@@ -140,7 +140,7 @@ gl_spot_recover=1
 gl_cloud_placement=${value_not_set}
 gl_cloud_networks_sys="duplicate"
 gl_preflight=0
-gl_pcp_state="--use_pcp"
+gl_use_pcp="--use_pcp"
 #
 # Global values
 #   gl_sys_file: sysctl files to use.
@@ -1931,7 +1931,7 @@ create_ansible_options()
 			echo "  test_exec_location: none"  >> ansible_vars_main.yml
 		fi
 
-		echo "  pcp_state: ${gl_pcp_state}" >> ansible_vars_main.yml
+		echo "  use_pcp: ${gl_use_pcp}" >> ansible_vars_main.yml
 		#
 		# More differences in the cloud space that has to be addressed here.
 		#
@@ -3332,7 +3332,7 @@ usage()
 	echo "  --no_spot_recover: Do not recover from a spot system going away."
 	echo "  --package_name <name>: Use this set of packages to override the default in the test config."
 	echo "    file instead of the default. Default format  package name <os>_pkg, new name <os>_pkg_<ver>."
-	echo "  --pcp_state 0/1:  If set to 0, pcp will not be used by the wrappers.  If set to 1, pcp will be"
+	echo "  --use_pcp 0/1:  If set to 0, pcp will not be used by the wrappers.  If set to 1, pcp will be"
 	echo "    used by the wrappers.  Default is 1."
 	echo "  --persistent_log: enable persistent logging"
 	echo "  --preflight_check: Performs various checks on the scenario file, and Zathras and then exits"
@@ -3566,14 +3566,6 @@ set_general_value()
 			fi
 			shift_by=2
 		;;
-		--pcp_state)
-			if [[ $2 -eq 1 ]]; then
-				gl_pcp_state="--use_pcp"
-			else
-				gl_pcp_state=""
-			fi
-			shift_by=2
-		;;
 		--persistent_log)
 			if [[ $gl_persistent_log -eq 0 ]]; then
 				echo "$1" >> $gl_cli_supplied_options
@@ -3770,6 +3762,15 @@ set_general_value()
 			usage "0"
 			shift_by=1
 		;;
+		--use_pcp)
+			echo "$1 $2" >> $gl_cli_supplied_options
+			if [[ $2 -eq 1 ]]; then
+				gl_use_pcp="--use_pcp"
+			else
+				gl_use_pcp=""
+			fi
+			shift_by=2
+		;;
 		--use_spot)
 			gl_use_spot=$2
 			shift_by=2
@@ -3813,7 +3814,6 @@ grab_cli_data()
 		"mode"
 		"os_vendor"
 		"package_name"
-		"pcp_state"
 		"results_prefix"
 		"retry_failed_tests"
 		"run_file"
@@ -3836,6 +3836,7 @@ grab_cli_data()
 		"tuned_reboot"
 		"update_target"
 		"upload_rpms"
+		"use_pcp"
 		"use_spot"
 	)
 

--- a/bin/burden
+++ b/bin/burden
@@ -140,6 +140,7 @@ gl_spot_recover=1
 gl_cloud_placement=${value_not_set}
 gl_cloud_networks_sys="duplicate"
 gl_preflight=0
+gl_pcp_state="--use_pcp"
 #
 # Global values
 #   gl_sys_file: sysctl files to use.
@@ -1930,6 +1931,7 @@ create_ansible_options()
 			echo "  test_exec_location: none"  >> ansible_vars_main.yml
 		fi
 
+		echo "  pcp_state: ${gl_pcp_state}" >> ansible_vars_main.yml
 		#
 		# More differences in the cloud space that has to be addressed here.
 		#
@@ -3330,6 +3332,8 @@ usage()
 	echo "  --no_spot_recover: Do not recover from a spot system going away."
 	echo "  --package_name <name>: Use this set of packages to override the default in the test config."
 	echo "    file instead of the default. Default format  package name <os>_pkg, new name <os>_pkg_<ver>."
+	echo "  --pcp_state 0/1:  If set to 0, pcp will not be used by the wrappers.  If set to 1, pcp will be"
+	echo "    used by the wrappers.  Default is 1."
 	echo "  --persistent_log: enable persistent logging"
 	echo "  --preflight_check: Performs various checks on the scenario file, and Zathras and then exits"
 	echo "  --results_prefix <prefix>: Run directory prefix"
@@ -3559,6 +3563,14 @@ set_general_value()
 			if [[ $gl_package_name == $value_not_set ]]; then
 				echo "$1 $2" >> $gl_cli_supplied_options
 				gl_package_name=$2
+			fi
+			shift_by=2
+		;;
+		--pcp_state)
+			if [[ $2 -eq 1 ]]; then
+				gl_pcp_state="--use_pcp"
+			else
+				gl_pcp_state=""
 			fi
 			shift_by=2
 		;;
@@ -3801,6 +3813,7 @@ grab_cli_data()
 		"mode"
 		"os_vendor"
 		"package_name"
+		"pcp_state"
 		"results_prefix"
 		"retry_failed_tests"
 		"run_file"

--- a/docs/command_line_reference.md
+++ b/docs/command_line_reference.md
@@ -61,6 +61,9 @@ Currently rhel, ubuntu, amazon, suse.
 ### --package_name \<name>
 Use this set of packages to override the default in the test config file instead of the default. Default format package name \<os>_pkg, new name \<os>_pkg_\<ver>.
 
+### --pcp_state 0/1
+If set to 0, pcp will not be used by the wrappers.  If set to 1, pcp will be used by the wrappers.  Default is 1.
+
 ### --persistent_log
 Enable persistent logging.
 
@@ -188,3 +191,4 @@ Name of the user to log into the system with. This setting will override the def
 
 ### --update_test_versions
 Will update the templates so we are using the latest versions of the test (git repos only).
+

--- a/docs/command_line_reference.md
+++ b/docs/command_line_reference.md
@@ -61,7 +61,7 @@ Currently rhel, ubuntu, amazon, suse.
 ### --package_name \<name>
 Use this set of packages to override the default in the test config file instead of the default. Default format package name \<os>_pkg, new name \<os>_pkg_\<ver>.
 
-### --pcp_state 0/1
+### --use_pcp 0/1
 If set to 0, pcp will not be used by the wrappers.  If set to 1, pcp will be used by the wrappers.  Default is 1.
 
 ### --persistent_log


### PR DESCRIPTION
# Description
Add the option to Zathras to turn on and off pcp in the wrappers.  PCP will be on by default.

Requires https://github.com/redhat-pehttps://github.com/redhat-performance/test_tools-wrappers/issues/112 to be fixed at the same time.

# Before/After Comparison
Before:  Zathras did nothing with the --use_pcp option to the wrappers.
After:  Zathras will nw set by default --use_pcp, user may override via --pcp_state 0

# Documentation Check
Yes.  Both usage for burden and the documentation has been updated.

# Clerical Stuff
This closes #314 

Relates to JIRA: RPOPC-683
