### PR TITLE
Fix it so /uploads exists.

### DIFF
--- a/ansible_roles/roles/upload_extra/tasks/main.yml
+++ b/ansible_roles/roles/upload_extra/tasks/main.yml
@@ -27,3 +27,10 @@
 - name: Upload extra files
   include_role:
     name: upload_extra_files
+
+#
+# Link uploads to /uploads if need be.
+#
+- name: upload the extra file info
+  shell: "ssh -oStrictHostKeyChecking=no {{ dyn_data.ssh_i_option }} {{ config_info.test_user }}@{{ dyn_data.test_hostname }} \"sudo ln -sf {{ dyn_data.kit_upload_directory }}/uploads /uploads\""
+

--- a/ansible_roles/roles/upload_extra/tasks/main.yml
+++ b/ansible_roles/roles/upload_extra/tasks/main.yml
@@ -21,16 +21,21 @@
     line: "status: success"
     create: yes
 
+- name: include dynamic info
+  include_vars:
+    file: "{{ working_dir }}/ansible_run_vars.yml"
+    name: dyn_data
+
+- name: make the uploads directory
+  shell: "ssh -oStrictHostKeyChecking=no {{ dyn_data.ssh_i_option }} {{ config_info.test_user }}@{{ dyn_data.test_hostname }} mkdir -p {{ dyn_data.kit_upload_directory }}"
+
+- name: Now link to /
+  shell: "ssh -oStrictHostKeyChecking=no {{ dyn_data.ssh_i_option }} {{ config_info.test_user }}@{{ dyn_data.test_hostname }} ln -s {{ dyn_data.kit_upload_directory }}/uploads /uploads"
+
+
 #
 # If we are pulling a file
 #
 - name: Upload extra files
   include_role:
     name: upload_extra_files
-
-#
-# Link uploads to /uploads if need be.
-#
-- name: upload the extra file info
-  shell: "ssh -oStrictHostKeyChecking=no {{ dyn_data.ssh_i_option }} {{ config_info.test_user }}@{{ dyn_data.test_hostname }} \"sudo ln -sf {{ dyn_data.kit_upload_directory }}/uploads /uploads\""
-

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -712,19 +712,16 @@
   become: true
   gather_facts: no
   tasks:
-  - name: upload to existing uplaods dir
-    block:
-    - name: include dynamic info
-      include_vars:
-        file: "{{ working_dir }}/ansible_run_vars.yml"
-        name: dyn_data
-    - name: handle_existing_uploads
-      include_role:
-        name: existing_uploads_dir
-      vars:
-        type: "uploads"
-        real_dir: "{{ dyn_data.kit_upload_directory }}"
-    when: config_info.kit_upload_directory != "none"
+  - name: include dynamic info
+    include_vars:
+      file: "{{ working_dir }}/ansible_run_vars.yml"
+      name: dyn_data
+  - name: handle_existing_uploads
+    include_role:
+      name: existing_uploads_dir
+    vars:
+      type: "uploads"
+      real_dir: "{{ dyn_data.kit_upload_directory }}"
 
 #
 # Now upload the file.  Due to Ansible copying the file first to ~/.ans* we need to do an ssh.
@@ -738,7 +735,6 @@
   - name: upload extra files
     include_role:
       name: upload_extra
-    when: config_info.kit_upload_directory != "none"
 
 - hosts: test_group
   vars_files:
@@ -749,19 +745,16 @@
   gather_facts: no
   tasks:
 
-  - name: Handle uploads
-    block:
-    - name: include dynamic info
-      include_vars:
-        file: "{{ working_dir }}/ansible_run_vars.yml"
-        name: dyn_data
-    - name: handle existing workloads dir
-      include_role:
-        name: existing_uploads_dir
-      vars:
-        type: "workloads"
-        real_dir: "{{ dyn_data.kit_upload_directory }}"
-    when: config_info.kit_upload_directory != "none"
+  - name: include dynamic info
+    include_vars:
+      file: "{{ working_dir }}/ansible_run_vars.yml"
+      name: dyn_data
+  - name: handle existing workloads dir
+    include_role:
+      name: existing_uploads_dir
+    vars:
+      type: "workloads"
+      real_dir: "{{ dyn_data.kit_upload_directory }}"
 
 #
 # retrieve the test

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -708,25 +708,27 @@
   vars_files:
     - ansible_vars.yml
     - upload_files.yml
-  user: root
+  remote_user: root
   become: true
   gather_facts: no
   tasks:
-  - name: include dynamic info
-    include_vars:
-      file: "{{ working_dir }}/ansible_run_vars.yml"
-      name: dyn_data
-  - name: handle_existing_uploads
-    include_role:
-      name: existing_uploads_dir
-    vars:
-      type: "uploads"
-      real_dir: "{{ dyn_data.kit_upload_directory }}"
+  - name: upload to existing uplaods dir
+    block:
+    - name: include dynamic info
+      include_vars:
+        file: "{{ working_dir }}/ansible_run_vars.yml"
+        name: dyn_data
+    - name: handle_existing_uploads
+      include_role:
+        name: existing_uploads_dir
+      vars:
+        type: "uploads"
+        real_dir: "{{ dyn_data.kit_upload_directory }}"
+    when: config_info.kit_upload_directory != "none"
 
- #
- # Now upload the file.  Due to Ansible copying the file first to ~/.ans* we need to do an ssh.
- #
- #
+#
+# Now upload the file.  Due to Ansible copying the file first to ~/.ans* we need to do an ssh.
+#
 - hosts: localhost
   vars_files:
     - ansible_vars.yml
@@ -736,6 +738,7 @@
   - name: upload extra files
     include_role:
       name: upload_extra
+    when: config_info.kit_upload_directory != "none"
 
 - hosts: test_group
   vars_files:
@@ -745,16 +748,20 @@
   become: true
   gather_facts: no
   tasks:
-  - name: include dynamic info
-    include_vars:
-      file: "{{ working_dir }}/ansible_run_vars.yml"
-      name: dyn_data
-  - name: handle existing workloads dir
-    include_role:
-      name: existing_uploads_dir
-    vars:
-      type: "workloads"
-      real_dir: "{{ dyn_data.kit_upload_directory }}"
+
+  - name: Handle uploads
+    block:
+    - name: include dynamic info
+      include_vars:
+        file: "{{ working_dir }}/ansible_run_vars.yml"
+        name: dyn_data
+    - name: handle existing workloads dir
+      include_role:
+        name: existing_uploads_dir
+      vars:
+        type: "workloads"
+        real_dir: "{{ dyn_data.kit_upload_directory }}"
+    when: config_info.kit_upload_directory != "none"
 
 #
 # retrieve the test


### PR DESCRIPTION
# Description
Restores the existence of /uploads

# Before/After Comparison
Before:  Uploads of kits occured, but the common location /uploads is missing.
After: /uploads is present again, allowing the execution of wrappers requiring uploaded kits.

# Documentation Check
No
# Clerical Stuff
This closes #320
to close the issue out automatically.

Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-698