### PR TITLE
Add Container image for Zathras

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github
+docs
+cli_examples
+ci

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -1,0 +1,41 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  containerize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Quay
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_UNAME }}
+          password: ${{ secrets.QUAY_PASSWD }}
+        
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: quay.io/zathras/zathras:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: Containerfile
+
+      - name: Build
+        if: github.event_name != 'push'
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          tags: quay.io/zathras/zathras:latest
+          cache-from: type=gha
+          file: Containerfile

--- a/Containerfile
+++ b/Containerfile
@@ -14,3 +14,5 @@ COPY . /zathras
 
 ENV PATH="/root/.local/bin:$PATH"
 ENV AWS_DEFAULT_OUTPUT="json"
+
+ENTRYPOINT ["./burden"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,13 @@
+FROM registry.fedoraproject.org/fedora:43
+
+RUN dnf config-manager addrepo --from-repofile=https://rpm.releases.hashicorp.com/fedora/hashicorp.repo && \
+    dnf install -y ssh-agent terraform python3-pip ansible-core hostname gh jq bc && pip3 install awscli
+# SSH directory management since it'll be needed later
+RUN mkdir ~/.ssh && chmod 700 ~/.ssh
+
+WORKDIR /zathras
+COPY ./bin/ /zathras/bin
+RUN sh -c 'yes | ./bin/install.sh'
+COPY . /zathras
+
+ENV PATH "/root/.local/bin:$PATH"

--- a/Containerfile
+++ b/Containerfile
@@ -12,4 +12,5 @@ RUN dnf clean all && rm -rf /var/cache/dnf/
 
 COPY . /zathras
 
-ENV PATH "/root/.local/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"
+ENV AWS_DEFAULT_OUTPUT="json"

--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,8 @@ RUN mkdir ~/.ssh && chmod 700 ~/.ssh
 WORKDIR /zathras
 COPY ./bin/ /zathras/bin
 RUN sh -c 'yes | ./bin/install.sh'
+RUN dnf clean all && rm -rf /var/cache/dnf/
+
 COPY . /zathras
 
 ENV PATH "/root/.local/bin:$PATH"

--- a/bin/burden
+++ b/bin/burden
@@ -941,7 +941,10 @@ set_region_zone_defaults()
 	if [[ $gl_system_type == "aws" ]]; then
 		gl_cloud_region=`aws configure get region`
 		if [ $? -eq 1 ]; then
-			cleanup_and_exit "Unable to retrieve the AWS region" 1
+			if [[ -z "$AWS_DEFAULT_REGION" ]]; then
+				cleanup_and_exit "Unable to retrieve the AWS region" 1
+			fi
+			gl_cloud_region="$AWS_DEFAULT_REGION"
 		fi
 		obtain_zone
 	elif [[ $gl_system_type == "azure" ]]; then

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,0 +1,36 @@
+# Container Usage
+## Quickstart
+`podman run -v $SSH_KEY_PATH:/ssh -v $SCENARIO_PATH:/configs quay.io/zathras/zathras --scenario /configs/scenario --ssh_key_file /ssh/privkey.key`
+
+## Supported Configurations
+| Cloud type | Supported |
+|------------|-----------|
+| Local Systems | :white_check_mark: |
+| AWS | :white_check_mark:|
+| Azure | :x: |
+| GCP | :x: |
+| IBM Cloud | :x: |
+
+## Volumes
+
+### SSH Keys
+SSH keys should be placed in their own volume, and it can be mounted anywhere, so long as `--ssh_key_file` is set to a key in that path.
+#### Sample Volme mount
+`-v $SSH_PATH:/ssh ... --ssh_key_file /ssh/$PRIVKEY`
+
+### Scenario Files
+Scenario files can be placed in a volume, and can also be mounted anywhere, so long as `--scenario` is provided to a file at the mounted path.
+#### Sample Volme mount
+`-v $SCENARIO_PATH:/scenarios ... --scenario /scenarios/$FILE`
+
+### Local Configs
+Local configs should be placed in a volume, but it cannot be mounted anywhere, it must be mounted at `/zathras/local_configs`.
+#### Sample Volme mount
+`-v $CONFIG_PATH:/zathras/local_configs`
+
+## Enviornment Variables
+| Variable Name | Cloud Type | Purpose |
+|---------------|------------|---------|
+| `AWS_ACCESS_KEY_ID` | AWS | Credentials to create AWS systems |
+| `AWS_SECRET_ACCESS_KEY` | AWS | Credentials to create AWS systems |
+| `AWS_DEFAULT_REGION` | AWS | Region to create the AWS system(s) |


### PR DESCRIPTION
# Description
This PR adds a container build process for Zathras.  This will make it much easier to use Zathras in CI/CD enviornments or for people who do not want to deal with setting up their system with all the required dependencies Zathras requires.

This PR also separately allows for the `AWS_DEFAULT_REGION` env var to set the AWS enviornment if a AWS configuration is not found.  This is useful in CI/CD enviornments where credentials and configurations are primarily provided through enviornment variables.

# Before/After Comparison
## Before
The user had to install the dependencies required for Zathras through the install script, which could be problematic if they had a newer `yq` or `jq` version.  CI/CD enviornments need to stand up the dependencies manually.

CI/CD users needed to build an AWS config within the container.

## After
The user can simply run everything from the `quay.io/zathras/zathras` container.

CI/CD users can use `AWS_DEFAULT_REGION` instead of building an AWS config file.

# Documentation Check
Docs will be needed, will come soon

# Clerical Stuff
This closes #336 

Relates to JIRA: RPOPC-711
