### PR TITLE
Fix it so uploads will only be created on writeable filesystems.

### DIFF
--- a/ansible_roles/roles/upload_disk_space/tasks/main.yml
+++ b/ansible_roles/roles/upload_disk_space/tasks/main.yml
@@ -21,9 +21,9 @@
 
 - name: upload the extra file info, determine location
   block:
-  - name: Get the free space
-    command: "ssh -oStrictHostKeyChecking=no {{ dyn_data.ssh_i_option }} {{ config_info.test_user }}@{{ dyn_data.test_hostname }} 'df --local --output=avail,target,source | grep -v Mounted | grep -v tmpfs | sort -n | tail -1 | xargs | sed \"s/ /:/g\" | cut -d: -f2'"
-    register: largest_dir
+  - name: Find largest writable filesystem
+    shell: "ssh -oStrictHostKeyChecking=no {{ dyn_data.ssh_i_option }} {{ config_info.test_user }}@{{ dyn_data.test_hostname }} \"tools_bin/writeable_filesys --most_free_space\""
+    register: largest_writable_fs
 
   #
   # Record the location to upload to
@@ -31,7 +31,7 @@
   - name: Write upload dir to  ansible_run_vars.yml
     lineinfile:
       path: "{{ working_dir }}/ansible_run_vars.yml"
-      line: "kit_upload_directory: {{ largest_dir.stdout }}"
+      line: "kit_upload_directory: {{ largest_writable_fs.stdout }}"
   when: 
     - config_info.kit_upload_directory == "none"
     - config_info.bootc_mode != 1

--- a/tools_bin/writeable_filesys
+++ b/tools_bin/writeable_filesys
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+most_free_space=0
+usage()
+{
+	echo "Usage $1:"
+	echo "No option, shows the following for all writeable filesystems (not tmpfs)"
+	echo " <free_space> <mount point> <device>"
+	echo "  --most_free_space:  provide the mount point of the filesystem with the most free space"A
+	echo "  -h --usage: this usage message"
+        exit 0
+}
+
+NO_ARGUMENTS=(
+	"most_free_space"
+	"usage"
+)
+
+opts=$(getopt \
+        --longoptions "$(printf "%s," "${NO_ARGUMENTS[@]}")" \
+        --name "$(basename "$0")" \
+        --options "h" \
+        -- "$@"
+)
+
+eval set --$opts
+
+while [[ $# -gt 0 ]]; do
+        case "$1" in
+		--most_free_space)
+			most_free_space=1
+			shift 1
+		;;
+		--usage)
+			usage $0
+		;;
+		-h)
+			usage $0
+		;;
+		--)
+			break
+		;;
+		*)
+			echo option not found $1
+			usage $0
+		;;
+        esac
+done
+
+
+worker_mnt=`mktemp /tmp/zathras_fs.XXXXX`
+worker_fsys=`mktemp /tmp/zathras_fs.XXXXX`
+out_file=`mktemp /tmp/zathras_fs.XXXXX`
+mount | grep ' (rw,' > $worker_mnt
+
+df --local --output=avail,target,source | grep -ve 'mounted\|tmpfs\|boot' | grep -v "Mounted on" > $worker_fsys
+
+while IFS= read -r mnt_data
+do
+	device=`echo $mnt_data | awk '{print $3}'`
+	grep -q "^${device} " $worker_mnt
+	if [[ $? -eq 0 ]]; then
+		echo $mnt_data  >> $out_file
+	fi
+done < "$worker_fsys"
+
+if [[ $most_free_space -eq 1 ]]; then
+	sort -n $out_file | tail -1 | awk '{print $2}'
+else
+	sort -n $out_file
+fi
+rm -f $worker_fsys $worker_mnt $out_file
+exit 0

--- a/tools_bin/writeable_filesys
+++ b/tools_bin/writeable_filesys
@@ -6,7 +6,7 @@ usage()
 	echo "Usage $1:"
 	echo "No option, shows the following for all writeable filesystems (not tmpfs)"
 	echo " <free_space> <mount point> <device>"
-	echo "  --most_free_space:  provide the mount point of the filesystem with the most free space"A
+	echo "  --most_free_space:  provide the mount point of the filesystem with the most free space"
 	echo "  -h --usage: this usage message"
         exit 0
 }


### PR DESCRIPTION
# Description
Uploads need to be created on a filesystem that is writeable.  Issue from bootc

# Before/After Comparison
Before:  If the filesystem that had the most free space was readonly, the upload creation/operation will fail.
After:  Zathras now filters out the read only filesystems for upload creation, so upload is not created there.

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

# Clerical Stuff
This closes #338
Relates to JIRA: RPOPC-741

Testing.
Ran to system that filesys with the most free space was read only, Zathras did not attempt to use it.
Verified that uploading of results still works properly.
