### PR TITLE
[Container] Add aarch64 image type

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -29,6 +29,7 @@ jobs:
           tags: quay.io/zathras/zathras:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
           file: Containerfile
 
       - name: Build

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -39,4 +39,5 @@ jobs:
           push: false
           tags: quay.io/zathras/zathras:latest
           cache-from: type=gha
+          platforms: linux/amd64,linux/arm64
           file: Containerfile


### PR DESCRIPTION
# Description
Adds an aarch64 container to be built along with the x86_64 container.

# Before/After Comparison
## Before
There is no aarch64 container build

## After
An aarch64 container is built along with x86_64 container under the same name.

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

Nope

# Clerical Stuff
Closes #340 

Relates to JIRA: RPOPC-752
