### PR TITLE
Add in tag default file.

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -1533,7 +1533,7 @@ generate_tags()
   		echo "  Jirald: ${1}" >> tags_defaults
 	fi
 	#
-	# If ~/.config/zathras/cloud_tags exsists, replace the various tags.
+	# If ~/.config/zathras/cloud_tags exists, replace the various tags.
 	# 
 
 	rm -f tag_temp

--- a/bin/burden
+++ b/bin/burden
@@ -1533,6 +1533,28 @@ generate_tags()
   		echo "  Jirald: ${1}" >> tags_defaults
 	fi
 	#
+	# If ~/.config/zathras/cloud_tags exsists, replace the various tags.
+	# 
+
+	rm -f tag_temp
+	if [[ -f "${HOME}/.config/zathras/cloud_tags" ]]; then
+		while IFS= read -r line
+		do
+			name=`echo $line | cut -d':'  -f 1`
+			while IFS= read -r tag_value
+			do
+				field=`echo $tag_value | cut -d':' -f 1`
+				echo $field | grep -q $name
+				if [[ $? -eq 0 ]]; then
+					echo "$line"  >>  tag_temp
+				else
+					echo "$tag_value" >> tag_temp
+				fi
+			done < "tags_defaults"
+			mv tag_temp tags_defaults
+		done < "${HOME}/.config/zathras/cloud_tags"
+	fi
+	#
 	# OK now add the variable information into the various files
 	# This sets them up to be set  when the system is created or
 	# shortly after it is created via terraform.  The various
@@ -1608,6 +1630,7 @@ generate_tags()
 	fi
 	echo "}" >> add_main_vars.tf
 }
+
 #
 #  Using all the options entered, create the working directory for the configuration and it's
 #  associated files.

--- a/bin/burden
+++ b/bin/burden
@@ -1540,10 +1540,10 @@ generate_tags()
 	if [[ -f "${HOME}/.config/zathras/cloud_tags" ]]; then
 		while IFS= read -r line
 		do
-			name=`echo $line | cut -d':'  -f 1`
+			name=`echo "$line" | cut -d':'  -f 1`
 			while IFS= read -r tag_value
 			do
-				field=`echo $tag_value | cut -d':' -f 1`
+				field=`echo "$tag_value" | cut -d':' -f 1`
 				echo $field | grep -q $name
 				if [[ $? -eq 0 ]]; then
 					echo "$line"  >>  tag_temp

--- a/bin/burden
+++ b/bin/burden
@@ -1544,7 +1544,7 @@ generate_tags()
 			while IFS= read -r tag_value
 			do
 				field=`echo "$tag_value" | cut -d':' -f 1`
-				echo $field | grep -q $name
+				echo $field | grep -q "$name"
 				if [[ $? -eq 0 ]]; then
 					echo "$line"  >>  tag_temp
 				else

--- a/docs/tag_default_file.md
+++ b/docs/tag_default_file.md
@@ -1,0 +1,6 @@
+# Description
+File: ~/.config/zathras/cloud_tags
+
+Any tag present in the config/tags.conf file may be set here.  The value in here will.
+override any value set in in configs/tags.conf.
+


### PR DESCRIPTION
# Description
Assigning tags will now check .config/zathras/cloud_tags for tags to assign.

# Before/After Comparison
Before: Required the user to always update tags.config to set the tags
After: The user now is able to set the values once in the .config/zathras/cloud_tags file, and the values will be used
            everytime

# Documentation Check
Yes, updates made.

# Clerical Stuff
This closes #342 

Relates to JIRA: RPOPC-753
