### PR TITLE
feat: add --no_pip_packages and --no_system_packages options

### DIFF
--- a/ansible_roles/roles/test_generic/tasks/main.yml
+++ b/ansible_roles/roles/test_generic/tasks/main.yml
@@ -80,6 +80,8 @@
         --sysname "{{ config_info.host_or_cloud_inst }}"
         --sys_type {{ config_info.system_type }}
         {{ "--no_pkg_install" if config_info.do_not_install_packages else "" }}
+        {{ "--no_pip_packages" if config_info.do_not_install_pip_packages else "" }}
+        {{ "--no_system_packages" if config_info.do_not_install_system_packages else "" }}
         {{ config_info.use_pcp }}
         {{ test_data.test_specific }}
 

--- a/bin/burden
+++ b/bin/burden
@@ -3535,6 +3535,8 @@ set_general_value()
 		--no_packages)
 			echo "$1" >> $gl_cli_supplied_options
 			gl_no_packages=1
+			gl_no_pip_packages=1
+			gl_no_system_packages=1
 			shift_by=1
 		;;
 		--no_pip_packages)

--- a/bin/burden
+++ b/bin/burden
@@ -223,6 +223,8 @@ gl_cloud_disk_type=""
 gl_zathras_specific_vals="config/zathras_specific_vals_def"
 gl_zathras_specific_vals_set=0
 gl_no_packages=0
+gl_no_pip_packages=0
+gl_no_system_packages=0
 gl_bootc_mode=0
 gl_cpu_type_request="none"
 gl_run_file=""
@@ -1851,6 +1853,8 @@ create_ansible_options()
 		echo "  "cloud_placement: $gl_cloud_placement >> ansible_vars_main.yml
 		echo "  "run_label: ${gl_run_prefix}_${gl_os_vendor} >> ansible_vars_main.yml
 		echo "  "do_not_install_packages: ${gl_no_packages} >> ansible_vars_main.yml
+		echo "  "do_not_install_pip_packages: ${gl_no_pip_packages} >> ansible_vars_main.yml
+		echo "  "do_not_install_system_packages: ${gl_no_system_packages} >> ansible_vars_main.yml
 		echo "  "bootc_mode: ${gl_bootc_mode} >> ansible_vars_main.yml
 		echo "  "error_repo_errors: ${gl_error_repo_errors} >> ansible_vars_main.yml
 		spot_pricing=0
@@ -3323,6 +3327,8 @@ usage()
 	echo "  --mode <mode>: Operating mode. Use 'image' for bootc-based hosts (skips packages, uses safe upload paths)."
 	echo "  --no_clean_up: Do not cleanup at the end of the test"
 	echo "  --no_packages: Do not install any packages. The default is no."
+	echo "  --no_pip_packages: Do not install pip packages. The default is no."
+	echo "  --no_system_packages: Do not install system packages (via dnf/apt/etc). The default is no."
 	echo "  --no_spot_recover: Do not recover from a spot system going away."
 	echo "  --package_name <name>: Use this set of packages to override the default in the test config."
 	echo "    file instead of the default. Default format  package name <os>_pkg, new name <os>_pkg_<ver>."
@@ -3529,6 +3535,16 @@ set_general_value()
 		--no_packages)
 			echo "$1" >> $gl_cli_supplied_options
 			gl_no_packages=1
+			shift_by=1
+		;;
+		--no_pip_packages)
+			echo "$1" >> $gl_cli_supplied_options
+			gl_no_pip_packages=1
+			shift_by=1
+		;;
+		--no_system_packages)
+			echo "$1" >> $gl_cli_supplied_options
+			gl_no_system_packages=1
 			shift_by=1
 		;;
 		--mode)
@@ -3840,6 +3856,8 @@ grab_cli_data()
 		"ignore_repo_errors"
 		"no_clean_up"
 		"no_packages"
+		"no_pip_packages"
+		"no_system_packages"
 		"no_spot_recover"
 		"persistent_log"
 		"preflight_check"

--- a/docs/command_line_reference.md
+++ b/docs/command_line_reference.md
@@ -52,6 +52,12 @@ Do not cleanup at the end of the test.
 ### --no_packages
 Do not install any packages, default is no.
 
+### --no_pip_packages
+Do not install python pip packages, default is no.
+
+### --no_system_packages
+Do not install system packages via dnf/apt/zypper/etc, default is no.
+
 ### --no_spot_recover
 Do not recover from a spot system going away.
 


### PR DESCRIPTION
### **User description**
# Description
Add two new command-line options to control package installation:
- --no_pip_packages: Skip installation of pip packages
- --no_system_packages: Skip installation of system packages (dnf/apt/etc)

These options complement the existing --no_packages flag and provide more granular control over which package types are installed.

Changes:
- burden: Add global variables, argument parsing, and ansible vars output
- test_generic ansible role: Pass flags to test execution script
- Updated usage documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Before/After Comparison
## Before
Only `--no_packages` was allowed, this would result in neither system packages AND pip packages being installed.  This is fine for instances like `bootc` based hosts, but for other instances, we want to test without installing system packages and with installing pip packages.

## After
Adds `- --no_pip_packages` and `--no_system_packages` flags, which prevent installing their respective types of packages. `--no_packages` is still available and behaves as normal.

# Documentation Check
Docs need to be updated.

# Clerical Stuff
Closes #346 

Relates to JIRA: RPOPC-806

## Relevant Logs
Will come shortly


___

### **PR Type**
Enhancement


___

### **Description**
- Add `--no_pip_packages` flag for granular pip package control

- Add `--no_system_packages` flag for granular system package control

- Pass new flags through ansible test execution pipeline

- Update usage documentation with new options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Arguments<br/>--no_pip_packages<br/>--no_system_packages"]
  BURDEN["burden Script<br/>Parse & Store Flags"]
  ANSIBLE["Ansible Variables<br/>do_not_install_pip_packages<br/>do_not_install_system_packages"]
  TEST["Test Execution<br/>Pass Flags to Script"]
  CLI -- "Parse arguments" --> BURDEN
  BURDEN -- "Output to vars" --> ANSIBLE
  ANSIBLE -- "Pass to test" --> TEST
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>burden</strong><dd><code>Add granular package control flags and parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/burden

<ul><li>Add two new global variables <code>gl_no_pip_packages</code> and <br><code>gl_no_system_packages</code> initialized to 0<br> <li> Add argument parsing for <code>--no_pip_packages</code> and <code>--no_system_packages</code> <br>flags in <code>set_general_value()</code> function<br> <li> Output new flags to ansible variables file in <code>create_ansible_options()</code> <br>function<br> <li> Add new flags to <code>NO_ARGUMENTS</code> array in <code>grab_cli_data()</code> function<br> <li> Update usage documentation to describe the two new options</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-performance/zathras/pull/347/files#diff-a0a3d0c886b278e3f4bcfe3e6c64263ca7b6c5f039a1175088f35f5fd6745045">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.yml</strong><dd><code>Pass new package flags to test script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible_roles/roles/test_generic/tasks/main.yml

<ul><li>Add conditional output of <code>--no_pip_packages</code> flag to command line if <br><code>config_info.do_not_install_pip_packages</code> is set<br> <li> Add conditional output of <code>--no_system_packages</code> flag to command line if <br><code>config_info.do_not_install_system_packages</code> is set<br> <li> Flags are passed to the test execution script via command line <br>arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-performance/zathras/pull/347/files#diff-8a8871a4789b54e6e0ed8f073eda2423543e1968f45ddd7c45a0bfb67274c7a9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

