### PR TITLE
Update the test versions to be the latest.

### DIFF
--- a/config/autohpl.yml
+++ b/config/autohpl.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/autohpl-wrapper/archive/refs/tags
-exec_dir: "autohpl-wrapper-2.0/auto_hpl"
-repo_file: "v2.0.tar.gz"
+exec_dir: "autohpl-wrapper-2.1/auto_hpl"
+repo_file: "v2.1.tar.gz"
 rhel_pkgs: gcc,make,gcc-gfortran,openblas-openmp,openmpi,openmpi-devel,wget,bc,perf,git,unzip
 ubuntu_pkgs: gcc,make,g++,python3-pip,mpi,libopenblas-base,mpi-default-bin,mpi-default-dev,mpi-specs,libmkl-intel-thread,libmkl-intel-ilp64,libmkl-intel-lp64,libmkl-core,libmkl-gnu-thread,zip,unzip
 amazon_pkgs: git,gcc,make,gcc-gfortran,blas,openmpi,openmpi-devel,wget,bc,zip,unzip

--- a/config/coremark_template.yml
+++ b/config/coremark_template.yml
@@ -1,5 +1,5 @@
 location: https://github.com/redhat-performance/coremark-wrapper/archive/refs/tags
-exec_dir: "coremark-wrapper-2.1/coremark"
-repo_file: "v2.1.tar.gz"
+exec_dir: "coremark-wrapper-2.3/coremark"
+repo_file: "v2.3.tar.gz"
 test_script_to_run: coremark_run
 test_specific: "--iterations 5"

--- a/config/fio_template.yml
+++ b/config/fio_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/fio-wrapper/archive/refs/tags
-exec_dir: "fio-wrapper-2.1/fio"
-repo_file: "v2.1.tar.gz"
+exec_dir: "fio-wrapper-3.0/fio"
+repo_file: "v3.0.tar.gz"
 storage_required: "yes"
 test_script_to_run: fio_run
 test_specific: "--disks {{ dyn_data.storage }}"

--- a/config/hammerdb_template.yml
+++ b/config/hammerdb_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/hammerdb-wrapper/archive/refs/tags
-exec_dir: "hammerdb-wrapper-2.1/hammerdb"
-repo_file: "v2.1.tar.gz"
+exec_dir: "hammerdb-wrapper-2.2/hammerdb"
+repo_file: "v2.2.tar.gz"
 os_supported: all
 storage_required: "yes"
 test_script_to_run: hammerdb

--- a/config/iozone_template.yml
+++ b/config/iozone_template.yml
@@ -1,5 +1,5 @@
 location: https://github.com/redhat-performance/iozone-wrapper/archive/refs/tags
-exec_dir: "iozone-wrapper-2.1/iozone"
-repo_file: "v2.1.tar.gz"
+exec_dir: "iozone-wrapper-3.0/iozone"
+repo_file: "v3.0.tar.gz"
 storage_required: "yes"
 test_script_to_run: iozone_run.sh

--- a/config/linpack_template.yml
+++ b/config/linpack_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/linpack-wrapper/archive/refs/tags
-exec_dir: "linpack-wrapper-3.0/linpack"
-repo_file: "v3.0.tar.gz"
+exec_dir: "linpack-wrapper-3.1/linpack"
+repo_file: "v3.1.tar.gz"
 os_supported: all
 rhel_pkgs: bc,numactl,perf,git,unzip
 ubuntu_pkgs: unzip,zip,numactl

--- a/config/passmark_template.yml
+++ b/config/passmark_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/passmark-wrapper/archive/refs/tags
-exec_dir: "passmark-wrapper-2.1/passmark"
-repo_file: "v2.1.tar.gz"
+exec_dir: "passmark-wrapper-2.5/passmark"
+repo_file: "v2.5.tar.gz"
 test_script_to_run: passmark_run
 test_specific: "--iterations 5"
 upload_extra: "/home/exports/pt_linux_x64.zip /home/exports/pt_linux_arm64.zip"

--- a/config/speccpu2017_template.yml
+++ b/config/speccpu2017_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/speccpu2017-wrapper/archive/refs/tags
-exec_dir: "speccpu2017-wrapper-2.1/speccpu2017"
-repo_file: "v2.1.tar.gz"
+exec_dir: "speccpu2017-wrapper-2.2/speccpu2017"
+repo_file: "v2.2.tar.gz"
 storage_required: "yes"
 test_script_to_run: run_speccpu
 test_specific: "--test intrate,fprate"

--- a/config/specjbb_template.yml
+++ b/config/specjbb_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/specjbb-wrapper/archive/refs/tags
-repo_file: "v2.1.tar.gz"
-exec_dir: "specjbb-wrapper-2.1/specjbb"
+repo_file: "v2.2.tar.gz"
+exec_dir: "specjbb-wrapper-2.2/specjbb"
 java_required: "yes"
 test_script_to_run: specjbb_run
 upload_extra: "/home/exports/SPECjbb2005_kitv1.07.tar.gz"

--- a/config/streams_template.yml
+++ b/config/streams_template.yml
@@ -1,5 +1,5 @@
 location: https://github.com/redhat-performance/streams-wrapper/archive/refs/tags
-exec_dir: "streams-wrapper-2.1/streams"
-repo_file: "v2.1.tar.gz"
+exec_dir: "streams-wrapper-2.2/streams"
+repo_file: "v2.2.tar.gz"
 os_supported: all
 test_script_to_run: streams_run

--- a/config/uperf_template.yml
+++ b/config/uperf_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/uperf-wrapper/archive/refs/tags
-exec_dir: "uperf-wrapper-2.1/uperf"
-repo_file: "v2.1.tar.gz"
+exec_dir: "uperf-wrapper-2.2/uperf"
+repo_file: "v2.2.tar.gz"
 network_required: "yes"
 test_script_to_run: uperf_run
 test_specific: --client_ips {{ dyn_data.ct_uperf_server_ip }} --server_ips {{ dyn_data.ct_uperf_client_list }} --tests stream --numb_jobs 1 --packet_type tcp --packet_sizes 64 --time 60


### PR DESCRIPTION
# Description
updates test to the latest

# Before/After Comparison
Before: Using older version for tests
After: Uses the latest version of the tests

# Documentation Check
No

# Clerical Stuff
This closes #349 
to close the issue out automatically.

Relates to JIRA: RPOPC-828

All versions have been tested when they were pushed.  Note known issue with passmark needing different lib.   Fix for that is coming.