### PR TITLE
Remove stray '

### DIFF
--- a/bin/utils/test_versions_ops
+++ b/bin/utils/test_versions_ops
@@ -75,7 +75,7 @@ test_version_ops()
 			# We expect EPEL to be installed, which contains gh.
 			#
 			if  [[ $using_version == *"zip"* ]]; then
-				printf '%32s using head $s\n' $test_repo $using_version
+				printf '%32s using head %s\n' $test_repo $using_version
 				continue
 			fi
 			gh release view -R $repo $using_version --json tagName -q .tagName &> /dev/null

--- a/bin/utils/test_versions_ops
+++ b/bin/utils/test_versions_ops
@@ -75,7 +75,7 @@ test_version_ops()
 			# We expect EPEL to be installed, which contains gh.
 			#
 			if  [[ $using_version == *"zip"* ]]; then
-				printf "%32s using head $using_version\n" $test_repo $using_version
+				printf '%32s using head $using_version\n' $test_repo $using_version
 				continue
 			fi
 			gh release view -R $repo $using_version --json tagName -q .tagName &> /dev/null

--- a/bin/utils/test_versions_ops
+++ b/bin/utils/test_versions_ops
@@ -75,7 +75,7 @@ test_version_ops()
 			# We expect EPEL to be installed, which contains gh.
 			#
 			if  [[ $using_version == *"zip"* ]]; then
-				printf '%32s using head $using_version\n' $test_repo $using_version
+				printf '%32s using head $s\n' $test_repo $using_version
 				continue
 			fi
 			gh release view -R $repo $using_version --json tagName -q .tagName &> /dev/null

--- a/bin/utils/test_versions_ops
+++ b/bin/utils/test_versions_ops
@@ -75,7 +75,7 @@ test_version_ops()
 			# We expect EPEL to be installed, which contains gh.
 			#
 			if  [[ $using_version == *"zip"* ]]; then
-				printf "%32s using head $using_version\n"' $test_repo $using_version
+				printf "%32s using head $using_version\n" $test_repo $using_version
 				continue
 			fi
 			gh release view -R $repo $using_version --json tagName -q .tagName &> /dev/null


### PR DESCRIPTION
# Description
Removes a stray ' in bin/utils/test_versions_ops

# Before/After Comparison
Before: error out because of stray '
After: No longer error out

# Documentation Check

# Clerical Stuff
This closes #358 



Relates to JIRA: RPOPC-853

Testing:

--update_test versions now works, before errored out becauseo f the stray '