### PR TITLE
Fix test_version_ops by removing open single quote

### DIFF
--- a/bin/utils/test_versions_ops
+++ b/bin/utils/test_versions_ops
@@ -75,7 +75,7 @@ test_version_ops()
 			# We expect EPEL to be installed, which contains gh.
 			#
 			if  [[ $using_version == *"zip"* ]]; then
-				printf "%32s using head $using_version\n" $test_repo $using_version
+				printf "%32s using head %s\n" $test_repo $using_version
 				continue
 			fi
 			gh release view -R $repo $using_version --json tagName -q .tagName &> /dev/null

--- a/bin/utils/test_versions_ops
+++ b/bin/utils/test_versions_ops
@@ -75,7 +75,7 @@ test_version_ops()
 			# We expect EPEL to be installed, which contains gh.
 			#
 			if  [[ $using_version == *"zip"* ]]; then
-				printf "%32s using head $using_version\n"' $test_repo $using_version
+				printf "%32s using head $using_version\n" $test_repo $using_version
 				continue
 			fi
 			gh release view -R $repo $using_version --json tagName -q .tagName &> /dev/null


### PR DESCRIPTION
# Description
This PR fixes an error caused by an unmatched single quote in test_version_ops that caused commands such as `./burden --update_test_versions` to fail.

# Before/After Comparison
## Before
Before, attempting to update test versions results in an error.
```
gdumas@fedora:~/zathras$ ./burden --update_test_versions
/usr/bin/ansible
Running with ansible version: [core
Zathras developed using ansible version:  2.9.6
/home/gdumas/.local/bin/yq
Running with yq version 2.10.0, tested with 2.10.0
/usr/bin/jq
/usr/bin/python
Running with python version: Python 3.14.3
Zathras developed using python version:  3.7.4
/home/gdumas/zathras/./bin/utils/test_versions_ops: line 96: unexpected EOF while looking for matching `''
./bin/burden: line 4476: popd: directory stack empty
```
After, the command executes as expected.
```
gdumas@fedora:~/zathras$ ./burden --update_test_versions
Git version check.
                            Test     Using    latest    Ok
Updating version for hammerdb_template.yml from v2.2 to v2.3
```

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

No changes to documentation are required.

# Clerical Stuff
Mention the issue this PR works toward resolving.  If the 
PR completely solves the issue, use "This closes #x"
to close the issue out automatically.

This closes #360

Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-855
