### PR TITLE
Remove files that are not needed for run analysis.

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -825,20 +825,6 @@ create_test_run_file()
 }
 
 #
-# Determine what packages are needed for the test on this particular flavor linux.
-#
-obtain_required_packages()
-{
-	packages=$(find_test_def_field "test_info" "test_name" "$1" "${gl_os_vendor}_pkgs" )
-	if [[ "$packages" != $value_not_set ]]; then
-		worker=`echo $packages | sed "s/,/ /g"`
-		for i in $worker; do
-			echo "  - ${i}" >> install_choices
-		done
-	fi
-}
-
-#
 # Determine the files to upload and make sure they exist.
 #
 make_list_of_uploads()
@@ -1146,19 +1132,6 @@ determine_what_has_to_be_installed()
 {
 	worker=`echo $1 | cut -d' ' -f2- | sed "s/,/ /g"`
 
-	# Ensure we have a couple packages to install, keeps things nice and happy.
-	if [[ $gl_os_vendor == "ubuntu" ]]; then
-		echo "  - gzip" > install_choices
-	elif [[ $gl_os_vendor == "suse" ]]; then
-		echo "  - bc" > install_choices
-		echo "  - libnuma1" >> install_choices
-		echo "  - time" >> install_choices
-		echo "  - git" >> install_choices
-	else
-		echo "  - bc" > install_choices
-		echo "  - numactl" > install_choices
-		echo "  - time" >> install_choices
-	fi
 	echo "---" > upload_files.yml
 	echo "uploads:" >> upload_files.yml
 	#
@@ -1166,7 +1139,6 @@ determine_what_has_to_be_installed()
 	#
 	for local_test_name in ${worker};
 	do
-		obtain_required_packages $local_test_name
 		make_list_of_uploads $local_test_name
 		#
 		# create the *yml file to be used for the test.
@@ -1174,10 +1146,6 @@ determine_what_has_to_be_installed()
 		create_test_run_file $local_test_name
 	done
 	make_list_of_rpms_to_upload
-	echo "---" >> install_opts.yml
-	echo "pkg_install:" >> install_opts.yml
-	sort -u install_choices >> install_opts.yml
-
 }
 
 #
@@ -2191,6 +2159,7 @@ create_ansible_options()
 			else
 				test_sys=${gl_host_config}
 			fi
+			rm -f ansible_vars.yml
 			echo "system config: ${test_sys}" >> results_info
 			for i in `ls tests_to_run`
 			do

--- a/bin/burden
+++ b/bin/burden
@@ -2159,7 +2159,6 @@ create_ansible_options()
 			else
 				test_sys=${gl_host_config}
 			fi
-			rm -f ansible_vars.yml
 			echo "system config: ${test_sys}" >> results_info
 			for i in `ls tests_to_run`
 			do

--- a/bin/kick_off.sh
+++ b/bin/kick_off.sh
@@ -293,4 +293,17 @@ if [[ -f test_times ]]; then
         report_usage
 fi
 
+#
+# Remove links in the results directory.
+#
+find . -maxdepth 1 -type l -delete
+#
+# Remove unneeded status files
+#
+rm -f *status
+
+#
+# Remove  misc files
+#
+rm -rf terraform_data.yml test_info upload* ignore.yml tags_defaults ansible.cfg config ansible_install_group add_vars_tf add_main_vars.tf add_main_tf_vars ansible_test_group ansible_vars_main.yml
 exit 0

--- a/bin/kick_off.sh
+++ b/bin/kick_off.sh
@@ -305,5 +305,5 @@ rm -f *status
 #
 # Remove  misc files
 #
-rm -rf terraform_data.yml test_info upload* ignore.yml tags_defaults ansible.cfg config ansible_install_group add_vars_tf add_main_vars.tf add_main_tf_vars ansible_test_group ansible_vars_main.yml
+rm -rf terraform_data.yml test_info upload* ignore.yml tags_defaults ansible.cfg config ansible_install_group add_vars_tf add_main_vars.tf add_main_tf_vars ansible_test_group
 exit 0

--- a/bin/kick_off.sh
+++ b/bin/kick_off.sh
@@ -130,6 +130,10 @@ while getopts "a:c:d:f:s:S:t:l:" o; do
 done
 shift $((OPTIND-1))
 
+if [[ ! -d $direct ]]; then
+	echo $direct is not a directory
+	exit 101
+fi
 #
 # Clean house, populate, and set permissions
 #

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -401,7 +401,6 @@
   become: true
   vars_files:
     - ansible_vars.yml
-    - install_opts.yml
 
   gather_facts: yes
   tasks:
@@ -475,7 +474,6 @@
   become: true
   vars_files:
     - ansible_vars.yml
-    - install_opts.yml
 
   gather_facts: no
   tasks:
@@ -500,7 +498,6 @@
   become: true
   vars_files:
     - ansible_vars.yml
-    - install_opts.yml
 
   gather_facts: no
   tasks:

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -410,16 +410,6 @@
 
   - name: rhel installation
     block:
-    - name: install_pkgs
-      include_role:
-        name: install_packages
-      vars:
-        results_file: "/tmp/install_status"
-    - name: retrieve install package status
-      include_role:
-        name: retrieve_status
-      vars:
-        status_file: "install_status"
     - name: Gather the rpm package facts
       package_facts:
         manager: auto
@@ -466,80 +456,6 @@
       name: install_rpms
     vars:
       results_file: "/tmp/rpm_installs"
-
-# Install packages for other OSes
-- hosts: install_group
-  remote_user: config_info.test_user
-  become_user: root
-  become: true
-  vars_files:
-    - ansible_vars.yml
-
-  gather_facts: no
-  tasks:
-  - name: amazon/ubuntu installation
-    block:
-    - name: update apts
-      shell: "apt-get update -y"
-    - name: install_pkgs
-      include_role:
-        name: install_packages
-      vars:
-        results_file: "/tmp/install_status"
-    when:
-      - config_info.os_vendor == "ubuntu"
-      - config_info.init_system == "yes"
-      - config_info.do_not_install_packages == 0
-
-# Install packages for other OSes
-- hosts: install_group
-  remote_user: config_info.test_user
-  become_user: root
-  become: true
-  vars_files:
-    - ansible_vars.yml
-
-  gather_facts: no
-  tasks:
-  - name: amazon
-    block:
-    - name: install_pkgs
-      include_role:
-        name: install_packages
-      vars:
-        results_file: "/tmp/install_status"
-    when:
-      - config_info.os_vendor == "amazon"
-      - config_info.init_system == "yes"
-      - config_info.do_not_install_packages == 0
-  - name: suse
-    block:
-    - name: install_pkgs
-      include_role:
-        name: install_packages
-      vars:
-        results_file: "/tmp/install_status"
-    when:
-      - config_info.os_vendor == "suse"
-      - config_info.init_system == "yes"
-      - config_info.do_not_install_packages == 0
-
-#
-# Terminate if told to.
-# 
-- hosts: install_group
-  vars_files: ansible_vars.yml
-  gather_facts: no
-  tasks:
-  - name: Handle package install errors
-    block:
-    - name: retrieve install status
-      include_role:
-        name: retrieve_status
-      vars:
-        status_file: "install_status"
-      when:
-        - config_info.do_not_install_packages == 0
 
 #
 # Reboot the system if we did an update.


### PR DESCRIPTION
# Description
Cleans up the run directory of unneeded files
Also removes the creation of the install package file, as that is now done by the test wrappers themselves.

# Before/After Comparison
Before:  Many unneeded files in run directory after the run, cluttering up the area.
After: Files present are files needed to figure out what the run options were, results, and some debug if needed.
# Documentation Check
No

# Clerical Stuff
This closes #362 


Relates to JIRA: RPOPC-857

Testing

Ran the test verified that the results file from the test still appears, plus desired files.
PLAY RECAP *********************************************************************
ec2-3-14-82-103.us-east-2.compute.amazonaws.com : ok=75   changed=41   unreachable=0    failed=0    skipped=83   rescued=1    ignored=0   
localhost                  : ok=130  changed=85   unreachable=0    failed=0    skipped=88   rescued=0    ignored=0   

Finished coremark on m5.xlarge

Finished run_burden_1583444_

[dvalin]$ echo $?
0

