### PR TITLE
Remove the install status files before performing the requested

### DIFF
--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -228,7 +228,7 @@
 
   gather_facts: no
   tasks:
-  - name: Remove the tar_status file if it exists
+  - name: Remove the cr_status file if it exists
     ansible.builtin.file:
       path: /tmp/cr_status
       state: absent
@@ -354,7 +354,7 @@
   tasks:
   - name: enable SLES legacy module
     block:
-    - name: Remove the tar_status file if it exists
+    - name: Remove the sles_legacy_status file if it exists
       ansible.builtin.file:
         path: /tmp/sles_legacy_status
         state: absent
@@ -426,7 +426,7 @@
 
   - name: rhel installation
     block:
-    - name: Remove the tar_status file if it exists
+    - name: Remove the dev_env_status file if it exists
       ansible.builtin.file:
         path: /tmp/dev_env_status
         state: absent

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -189,6 +189,10 @@
   vars_files: ansible_vars.yml
   gather_facts: no
   tasks:
+  - name: Remove the tar_status file if it exists
+    ansible.builtin.file:
+      path: /tmp/tar_status
+      state: absent
   - name: install tools
     include_role:
       name: install_tools
@@ -224,6 +228,10 @@
 
   gather_facts: no
   tasks:
+  - name: Remove the tar_status file if it exists
+    ansible.builtin.file:
+      path: /tmp/cr_status
+      state: absent
   - name: install codeready repo (if RHEL)
     block:
     - name: Enable CodeReady Builder for AWS/Azure
@@ -346,6 +354,10 @@
   tasks:
   - name: enable SLES legacy module
     block:
+    - name: Remove the tar_status file if it exists
+      ansible.builtin.file:
+        path: /tmp/sles_legacy_status
+        state: absent
     - name: Enable sle-module-legacy/{{ ansible_distribution_version }}/{{ ansible_architecture }}
       shell: "SUSEConnect -p sle-module-legacy/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
       register: suse_connect_result
@@ -414,6 +426,10 @@
 
   - name: rhel installation
     block:
+    - name: Remove the tar_status file if it exists
+      ansible.builtin.file:
+        path: /tmp/dev_env_status
+        state: absent
     - name: Gather the rpm package facts
       package_facts:
         manager: auto


### PR DESCRIPTION

# Description
What does this PR do?  Give a short summary
Remove the install status files before performing the requested operation

# Before/After Comparison
Before:  If a prior run of zathras has resulted in an install failure, we will keep picking up on it in subsequent runs.
After:  The install status in the status file will be from the current run.

# Documentation Check
No

# Clerical Stuff
This closes #373 
to close the issue out automatically.

Relates to JIRA: RPOPC-891

Testing Done
Reproduced the issue, and got a bogus failure
After change
Ran the changes on account that was seeing the issue, no longer present (bare metal system)
Ran on a cloud system, everything is fine.