### PR TITLE
Update the test versions

### DIFF
--- a/config/autohpl.yml
+++ b/config/autohpl.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/autohpl-wrapper/archive/refs/tags
-exec_dir: "autohpl-wrapper-2.3/auto_hpl"
-repo_file: "v2.3.tar.gz"
+exec_dir: "autohpl-wrapper-2.4/auto_hpl"
+repo_file: "v2.4.tar.gz"
 rhel_pkgs: gcc,make,gcc-gfortran,openblas-openmp,openmpi,openmpi-devel,wget,bc,perf,git,unzip
 ubuntu_pkgs: gcc,make,g++,python3-pip,mpi,libopenblas-base,mpi-default-bin,mpi-default-dev,mpi-specs,libmkl-intel-thread,libmkl-intel-ilp64,libmkl-intel-lp64,libmkl-core,libmkl-gnu-thread,zip,unzip
 amazon_pkgs: git,gcc,make,gcc-gfortran,blas,openmpi,openmpi-devel,wget,bc,zip,unzip

--- a/config/coremark_template.yml
+++ b/config/coremark_template.yml
@@ -1,5 +1,5 @@
 location: https://github.com/redhat-performance/coremark-wrapper/archive/refs/tags
-exec_dir: "coremark-wrapper-2.4/coremark"
-repo_file: "v2.4.tar.gz"
+exec_dir: "coremark-wrapper-2.5/coremark"
+repo_file: "v2.5.tar.gz"
 test_script_to_run: coremark_run
 test_specific: "--iterations 5"

--- a/config/fio_template.yml
+++ b/config/fio_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/fio-wrapper/archive/refs/tags
-exec_dir: "fio-wrapper-3.2/fio"
-repo_file: "v3.2.tar.gz"
+exec_dir: "fio-wrapper-3.3/fio"
+repo_file: "v3.3.tar.gz"
 storage_required: "yes"
 test_script_to_run: fio_run
 test_specific: "--disks {{ dyn_data.storage }}"

--- a/config/linpack_template.yml
+++ b/config/linpack_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/linpack-wrapper/archive/refs/tags
-exec_dir: "linpack-wrapper-3.2/linpack"
-repo_file: "v3.2.tar.gz"
+exec_dir: "linpack-wrapper-3.3/linpack"
+repo_file: "v3.3.tar.gz"
 os_supported: all
 rhel_pkgs: bc,numactl,perf,git,unzip
 ubuntu_pkgs: unzip,zip,numactl

--- a/config/passmark_template.yml
+++ b/config/passmark_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/passmark-wrapper/archive/refs/tags
-exec_dir: "passmark-wrapper-2.7/passmark"
-repo_file: "v2.7.tar.gz"
+exec_dir: "passmark-wrapper-2.8/passmark"
+repo_file: "v2.8.tar.gz"
 test_script_to_run: passmark_run
 test_specific: "--iterations 5"
 upload_extra: "/home/exports/pt_linux_x64.zip /home/exports/pt_linux_arm64.zip"

--- a/config/phoronix_template.yml
+++ b/config/phoronix_template.yml
@@ -1,4 +1,4 @@
 location: https://github.com/redhat-performance/phoronix-wrapper/archive/refs/tags
-exec_dir: "phoronix-wrapper-3.3/phoronix"
-repo_file: "v3.3.tar.gz"
+exec_dir: "phoronix-wrapper-3.4/phoronix"
+repo_file: "v3.4.tar.gz"
 test_script_to_run: run_phoronix.sh

--- a/config/pyperformance_template.yml
+++ b/config/pyperformance_template.yml
@@ -1,4 +1,4 @@
 location: https://github.com/redhat-performance/pyperf-wrapper/archive/refs/tags
-exec_dir: "pyperf-wrapper-2.2/pyperf"
-repo_file: "v2.2.tar.gz"
+exec_dir: "pyperf-wrapper-2.4/pyperf"
+repo_file: "v2.4.tar.gz"
 test_script_to_run: pyperf_run

--- a/config/specjbb_template.yml
+++ b/config/specjbb_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/specjbb-wrapper/archive/refs/tags
-repo_file: "v2.4.tar.gz"
-exec_dir: "specjbb-wrapper-2.4/specjbb"
+repo_file: "v2.5.tar.gz"
+exec_dir: "specjbb-wrapper-2.5/specjbb"
 java_required: "yes"
 test_script_to_run: specjbb_run
 upload_extra: "/home/exports/SPECjbb2005_kitv1.07.tar.gz"

--- a/config/streams_template.yml
+++ b/config/streams_template.yml
@@ -1,5 +1,5 @@
 location: https://github.com/redhat-performance/streams-wrapper/archive/refs/tags
-exec_dir: "streams-wrapper-2.3/streams"
-repo_file: "v2.3.tar.gz"
+exec_dir: "streams-wrapper-2.5/streams"
+repo_file: "v2.5.tar.gz"
 os_supported: all
 test_script_to_run: streams_run

--- a/config/uperf_template.yml
+++ b/config/uperf_template.yml
@@ -1,6 +1,6 @@
 location: https://github.com/redhat-performance/uperf-wrapper/archive/refs/tags
-exec_dir: "uperf-wrapper-2.3/uperf"
-repo_file: "v2.3.tar.gz"
+exec_dir: "uperf-wrapper-2.4/uperf"
+repo_file: "v2.4.tar.gz"
 network_required: "yes"
 test_script_to_run: uperf_run
 test_specific: --client_ips {{ dyn_data.ct_uperf_server_ip }} --server_ips {{ dyn_data.ct_uperf_client_list }} --tests stream --numb_jobs 1 --packet_type tcp --packet_sizes 64 --time 60


### PR DESCRIPTION
# Description
Brings all the tests defined in config to be the latest version

# Before/After Comparison
Before: Ran with the older version of the wrapper
After: Runs now with the latest version of the wrapper.

# Documentation Check
No

# Clerical Stuff
This closes #377 


Relates to JIRA: RPOPC-897

Testing
All the new versions of the wrapper has been tested when the wrapper was pushed.
When test is executed, we find the proper version of all the wrappers (bad version of any wrapper, gets flagged).