### PR TITLE
Skip test version check

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -3872,6 +3872,10 @@ set_general_value()
 			gl_show_os_versions=1
 			shift_by=1
 		;;
+		--skip_test_version_check)                
+			gl_test_version_check=0
+            shift_by=1
+        ;;
 		--ssh_key_file)
 			if [[ $gl_ssh_key_file == "" ]]; then
 				echo "$1 $2" >> $gl_cli_supplied_options
@@ -4095,6 +4099,7 @@ grab_cli_data()
 		"run_chronicler_strict"
 		"show_os_versions"
 		"show_tests"
+		"skip_test_version_check"
 		"test_version_check"
 		"tf_list"
 		"tf_terminate_all"

--- a/bin/burden
+++ b/bin/burden
@@ -3557,6 +3557,7 @@ usage()
 	echo "  --ssh_key_file: Designates the ssh key file we are to use."
 	echo "  --show_os_versions: given the cloud type, and OS vendor, show the available os versions"
 	echo "  --show_tests:  list the available test as defined in config/test_defs.yml"
+	echo "  --skip_test_version_check:  Skip the initial check of test wrapper versions and just use what we have"
 	echo "  --test_def_file <file>: test definition file to use."
 	echo "  --test_def_dir <dir>: test definition directory.  Default is <execution dir>/config.  If"
 	echo "     https: or git: is at the start of the location, then we will pull from a git repo."

--- a/docs/command_line_reference.md
+++ b/docs/command_line_reference.md
@@ -136,6 +136,9 @@ Given the cloud type and OS vendor, show the available operating system versions
 ### --show_tests
 List the available test as defined in config/test_defs.yml
 
+### --skip_test_version_check
+Skip the initial check of test wrapper versions and just use what we have
+
 ### --test_def_file \<file>
 Test definition file to use.
  


### PR DESCRIPTION
# Description
This adds a --skip_test_version_check option to burden, which removes an "authentication required" call to GitHub and allows a user without a current token (e.g: a generic "hands off testing" user account) to execute a test run. This is a CPT enabler.

# Before/After Comparison
Before: When running a test as a user who hasn't (and potentially can't) complete the "gh auth" process, burden will exit out after variations on a theme of:
-----
      pyperformance_template.yml      v2.4        no      
Failure: https://github.com/redhat-performance/pyperf-wrapper, version v2.4 is not defined.
To get started with GitHub CLI, please run:  gh auth login
Alternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.
-----

After: The check for the latest test version is skipped ("use what we have") and burden is able to continue.

# Documentation Check
Yes. The internal usage information and readme have been updated

# Clerical Stuff
This closes #383 
Relates to JIRA: RPOPC-931
Relevant portion of burden output showing run starting without version check (hostname redacted):

``[JoeUser@hostname zathras]$ ./burden --scenario kluge.scen --retry_failed_tests 0 --results_prefix klugetest --skip_test_version_check
{'global': {'os_vendor': 'rhel', 'results_prefix': 'stvc_test', 'system_type': 'local'}, 'systems': {'system1': {'tests': 'coremark', 'host_config': 'hostname'}}}
Starting coremark on hostname
===== attempt 1 of 5 ==============

PLAY [local] *******************************************************************

TASK [terminate bad cpu type instance] *****************************************
skipping: [localhost]

TASK [Abort, all we are doing is killing off a bad cpu type instance.] *********
skipping: [localhost]

PLAY [local] *******************************************************************

