### PR TITLE
Claude assisted: Support for private Azure images.

### DIFF
--- a/ansible_roles/roles/azure_create/files/tf/README.md
+++ b/ansible_roles/roles/azure_create/files/tf/README.md
@@ -1,0 +1,122 @@
+# Azure Terraform Templates
+
+This directory contains Terraform templates for creating Azure virtual machines with support for both marketplace images and custom images from Azure Compute Gallery.
+
+## Image Source Options
+
+The templates support two types of image sources:
+
+### 1. Marketplace Images (URN-based)
+Uses Azure Marketplace images specified by publisher, offer, SKU, and version.
+
+**Example configuration:**
+```hcl
+use_custom_image = false
+publisher = "RedHat"
+offer     = "RHEL"
+sku       = "8-LVM"
+azversion = "latest"
+```
+
+### 2. Custom Images (Azure Compute Gallery or Managed Images)
+Uses custom images from Azure Compute Gallery or managed images specified by resource ID.
+
+**Example configuration:**
+```hcl
+use_custom_image = true
+az_urn_sub = "/subscriptions/xxxx/resourceGroups/yyyy/providers/Microsoft.Compute/galleries/zzzz/images/image-name/versions/1.0.0"
+```
+
+## Template Files
+
+### Unified Templates (Recommended)
+These templates automatically handle both image source types using Terraform conditional logic:
+
+- **`vm_spot_set_unified.tf`** - VM creation without network (simplified)
+- **`main_net_p2_unified.tf`** - VM creation with network configuration
+
+The unified templates use the `use_custom_image` boolean variable to determine which image source to use:
+- When `use_custom_image = true`: Uses `source_image_id` with the value from `az_urn_sub`
+- When `use_custom_image = false`: Uses `source_image_reference` block with marketplace parameters
+
+### Legacy Templates (Deprecated)
+These separate templates are maintained for backward compatibility but should be replaced by unified templates:
+
+- **URN-based (Marketplace):**
+  - `vm_spot_set_urn.tf`
+  - `main_net_p2_urn.tf`
+
+- **Custom Image (Subscription):**
+  - `vm_spot_set_sub.tf`
+  - `main_net_p2_sub.tf`
+
+## How It Works
+
+### 1. Variable Definition (`vars.tf`)
+```hcl
+variable "use_custom_image" {
+  type        = bool
+  default     = false
+  description = "Set to true to use custom image from Azure Compute Gallery (source_image_id), false to use marketplace image (source_image_reference)"
+}
+```
+
+### 2. Conditional Image Source (in unified templates)
+```hcl
+# Use source_image_id for Azure Compute Gallery or managed images
+source_image_id = var.use_custom_image ? var.az_urn_sub : null
+
+# Use source_image_reference for marketplace images
+dynamic "source_image_reference" {
+    for_each = var.use_custom_image ? [] : [1]
+    content {
+        publisher = var.publisher
+        offer     = var.offer
+        sku       = var.sku
+        version   = var.azversion
+    }
+}
+```
+
+### 3. Variable Setting (via Ansible)
+The `use_custom_image` variable is automatically set in the tfvars template based on `cloud_os_version`:
+- If `cloud_os_version == "none"` → `use_custom_image = true` (custom image)
+- Otherwise → `use_custom_image = false` (marketplace image)
+
+## Migration Notes
+
+When migrating from legacy templates to unified templates:
+
+1. The unified templates eliminate the need for separate template files based on image source
+2. All image source logic is handled within a single template using Terraform conditionals
+3. No changes required to existing variable definitions for `az_urn_sub`, `publisher`, `offer`, `sku`, or `azversion`
+4. The Ansible playbook is simplified by removing conditional template selection logic
+
+## Spot Instance Support
+
+All templates support both regular and spot instances through placeholder replacement:
+- `PRIORITYSPOT` → replaced with `priority = "Spot"` for spot instances or removed for regular instances
+- `EVICTIONPOLICY` → replaced with `eviction_policy = "Deallocate"` for spot instances or removed for regular instances
+
+## Examples
+
+### Using Marketplace Image (RHEL 8)
+```hcl
+use_custom_image = false
+publisher = "RedHat"
+offer     = "RHEL"
+sku       = "8-LVM"
+azversion = "latest"
+```
+
+### Using Azure Compute Gallery Image
+```hcl
+use_custom_image = true
+az_urn_sub = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myGalleryRG/providers/Microsoft.Compute/galleries/myGallery/images/myCustomImage/versions/1.0.0"
+```
+
+### Using Managed Image
+```hcl
+use_custom_image = true
+az_urn_sub = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myImagesRG/providers/Microsoft.Compute/images/myManagedImage"
+```

--- a/ansible_roles/roles/azure_create/files/tf/main_net_p2_unified.tf
+++ b/ansible_roles/roles/azure_create/files/tf/main_net_p2_unified.tf
@@ -1,0 +1,51 @@
+# And finally, create the virtual machine
+resource "azurerm_linux_virtual_machine" "virtualmachine" {
+    for_each             = local.system
+    name                  = "${var.run_label}-vm-${format("%02d",each.value.index)}"
+    location              = var.location
+    resource_group_name   = azurerm_resource_group.resource_group.name
+    network_interface_ids = ["${azurerm_network_interface.publicnic[each.value.index].id}","${azurerm_network_interface.testnic1[each.value.index].id}"]
+    size                  = each.value.sys
+    admin_username        = var.test_user
+
+    admin_ssh_key {
+        username   = var.test_user
+        public_key = file("~/.ssh/id_rsa.pub")
+    }
+    PRIORITYSPOT
+    EVICTIONPOLICY
+
+    os_disk {
+        name                 = "${var.run_label}-OS_Disk-${format("%02d",each.value.index)}"
+        caching              = "ReadWrite"
+        storage_account_type = "Premium_LRS"
+    }
+
+    # Use source_image_id for Azure Compute Gallery or managed images
+    source_image_id = var.use_custom_image ? var.az_urn_sub : null
+
+    # Use source_image_reference for marketplace images
+    dynamic "source_image_reference" {
+        for_each = var.use_custom_image ? [] : [1]
+        content {
+            publisher = var.publisher
+            offer     = var.offer
+            sku       = var.sku
+            version   = var.azversion
+        }
+    }
+    tags = local.tags
+}
+
+data "azurerm_public_ip" "publicip" {
+    count               = var.vm_count
+    name                = azurerm_public_ip.publicip[count.index].name
+    resource_group_name = azurerm_linux_virtual_machine.virtualmachine[count.index].resource_group_name
+}
+
+# Need to put data out for private
+data "azurerm_network_interface" "testnic1" {
+    count               = var.vm_count
+    name                = azurerm_network_interface.testnic1[count.index].name
+    resource_group_name = azurerm_linux_virtual_machine.virtualmachine[count.index].resource_group_name
+}

--- a/ansible_roles/roles/azure_create/files/tf/vars.tf
+++ b/ansible_roles/roles/azure_create/files/tf/vars.tf
@@ -121,3 +121,9 @@ variable "disk_size" {
   type    = string
   default = ""
 }
+
+variable "use_custom_image" {
+  type        = bool
+  default     = false
+  description = "Set to true to use custom image from Azure Compute Gallery (source_image_id), false to use marketplace image (source_image_reference)"
+}

--- a/ansible_roles/roles/azure_create/files/tf/vm_spot_set_unified.tf
+++ b/ansible_roles/roles/azure_create/files/tf/vm_spot_set_unified.tf
@@ -1,0 +1,35 @@
+# And finally, create the virtual machine
+resource "azurerm_linux_virtual_machine" "virtualmachine" {
+    count                 = var.vm_count
+    name                  = "${var.run_label}-vm"
+    location              = var.location
+    resource_group_name   = azurerm_resource_group.resource_group.name
+    network_interface_ids = [ azurerm_network_interface.publicnic[count.index].id]
+    size                  = var.machine_type
+    admin_username        = var.test_user
+    admin_ssh_key {
+        username   = var.test_user
+        public_key = file("~/.ssh/id_rsa.pub")
+    }
+    PRIORITYSPOT
+    EVICTIONPOLICY
+
+    os_disk {
+        caching              = "ReadWrite"
+        storage_account_type = "Premium_LRS"
+    }
+
+    # Use source_image_id for Azure Compute Gallery or managed images
+    source_image_id = var.use_custom_image ? var.az_urn_sub : null
+
+    # Use source_image_reference for marketplace images
+    dynamic "source_image_reference" {
+        for_each = var.use_custom_image ? [] : [1]
+        content {
+            publisher = var.publisher
+            offer     = var.offer
+            sku       = var.sku
+            version   = var.azversion
+        }
+    }
+}

--- a/ansible_roles/roles/azure_create/tasks/main.yml
+++ b/ansible_roles/roles/azure_create/tasks/main.yml
@@ -11,24 +11,14 @@
     copy:
       src: "tf/main_no_net.tf"
       dest: "{{ working_dir }}/tf/main.tf"
-  - name: Using urn for image.
+  - name: Using unified template for both marketplace and custom images
     block:
     - name: cat non spot machine terraform
-      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/vm_spot_set_urn.tf | sed \"s/PRIORITYSPOT//g\" | sed \"s/EVICTIONPOLICY//g\" >> {{ working_dir }}/tf/main.tf" 
+      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/vm_spot_set_unified.tf | sed \"s/PRIORITYSPOT//g\" | sed \"s/EVICTIONPOLICY//g\" >> {{ working_dir }}/tf/main.tf"
       when: config_info.spot_start_price == 0
     - name: cat spot machine terraform
-      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/vm_spot_set_urn.tf | sed \"s/PRIORITYSPOT/priority              = \\\"Spot\\\"/g\" | sed \"s/EVICTIONPOLICY/eviction_policy       = \\\"Deallocate\\\"/g\" >> {{ working_dir }}/tf/main.tf" 
+      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/vm_spot_set_unified.tf | sed \"s/PRIORITYSPOT/priority              = \\\"Spot\\\"/g\" | sed \"s/EVICTIONPOLICY/eviction_policy       = \\\"Deallocate\\\"/g\" >> {{ working_dir }}/tf/main.tf"
       when: config_info.spot_start_price == 1
-    when: config_info.cloud_os_version != "none"
-  - name: Using subscription for image.
-    block:
-    - name: cat non spot machine terraform
-      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/vm_spot_set_sub.tf | sed \"s/PRIORITYSPOT//g\" | sed \"s/EVICTIONPOLICY//g\" >> {{ working_dir }}/tf/main.tf" 
-      when: config_info.spot_start_price == 0
-    - name: cat spot machine terraform
-      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/vm_spot_set_sub.tf | sed \"s/PRIORITYSPOT/priority              = \\\"Spot\\\"/g\" | sed \"s/EVICTIONPOLICY/eviction_policy       = \\\"Deallocate\\\"/g\" >> {{ working_dir }}/tf/main.tf" 
-      when: config_info.spot_start_price == 1
-    when: config_info.cloud_os_version == "none"
   - name: copy output.tf
     copy:
       src: "tf/output_no_net.tf"
@@ -39,16 +29,10 @@
   block:
   - name: copy main_net_p1.tf to tf/main_net.tf
     shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/main_net_p1.tf | sed \"s/PRIORITYSPOT/priority              = \\\"Spot\\\"/g\" | sed \"s/EVICTIONPOLICY/eviction_policy       = \\\"Deallocate\\\"/g\" >> {{ working_dir }}/tf/main.tf"
-  - name: copy main_net_p2_urn.tf to work area for later use
+  - name: copy unified template for both marketplace and custom images
     block:
-    - name: copy for urn image.
-      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/main_net_p2_urn.tf | sed \"s/PRIORITYSPOT/priority              = \\\"Spot\\\"/g\" | sed \"s/EVICTIONPOLICY/eviction_policy       = \\\"Deallocate\\\"/g\"  >> {{ working_dir }}/tf/main_net_p2.tf"
-    when: config_info.cloud_os_version != "none"
-  - name: copy main_net_p2_sub.tf to work area for later use
-    block:
-    - name: copy for subscription urn, private
-      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/main_net_sub.tf | sed \"s/PRIORITYSPOT/priority              = \\\"Spot\\\"/g\" | sed \"s/EVICTIONPOLICY/eviction_policy       = \\\"Deallocate\\\"/g\"  >> {{ working_dir }}/tf/main_net_p2.tf"
-    when: config_info.cloud_os_version == "none"
+    - name: copy unified template
+      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/main_net_p2_unified.tf | sed \"s/PRIORITYSPOT/priority              = \\\"Spot\\\"/g\" | sed \"s/EVICTIONPOLICY/eviction_policy       = \\\"Deallocate\\\"/g\"  >> {{ working_dir }}/tf/main_net_p2.tf"
   - name: copy output.tf to tf/output_net.tf
     copy:
       src: "tf/output_net.tf"

--- a/ansible_roles/roles/azure_create/templates/tfvars.j2
+++ b/ansible_roles/roles/azure_create/templates/tfvars.j2
@@ -26,6 +26,13 @@ pb_disk_type = "Premium_LRS"
 pb_disk_count = 1
 pb_vol_size = 500
 
+# Determine image source type: true for custom image (Azure Compute Gallery), false for marketplace
+{% if config_info.cloud_os_version == "none" %}
+use_custom_image = true
+{% else %}
+use_custom_image = false
+{% endif %}
+
 # Check "cloud_numb_networks", default value is "1" for both vars
 {% if config_info.cloud_numb_networks >= 1 %}
 vm_count = 2

--- a/bin/burden
+++ b/bin/burden
@@ -437,7 +437,10 @@ azure_image_lookup()
 				rtc=$?
 			else
 				resource_group=`echo $urn | cut -d'/' -f 5`
-				az resource list --resource-group $resource_group | grep -q $urn
+				#
+				# Suppose to have upper case, but getting lower case, just ignore
+				# case.
+				az resource list --resource-group $resource_group | grep -iq $urn
 				rtc=$?
 			fi
 			if [[ $rtc -ne 0 ]]; then
@@ -1394,14 +1397,27 @@ azure_specific_os_version()
 	# The publisher field in the urn may be different case (go figure) then expected..
 	# So we need to go and pull the publisher from az_vm image show.
 	#
+	# Azure supports two types of image sources:
+	# 1. Marketplace images (URN format): publisher:offer:sku:version (e.g., RedHat:RHEL:8-LVM:latest)
+	# 2. Custom images from Azure Compute Gallery or Managed Images: resource ID path containing "subscription"
+	#    (e.g., /subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/galleries/.../images/.../versions/...)
+	#
+	# The Terraform templates use a boolean variable 'use_custom_image' to determine which source to use.
+	# This is set based on whether cloud_os_version has "subscription" as part of the name" (custom image) else it
+	# is marketplace.
+	#
 	az_subscription=`az account show | grep id | cut -d'"' -f 4`
 	if [[ $gl_cloud_os_version == *"subscription"* ]]; then
+		# Custom image from Azure Compute Gallery or Managed Image
+		# Set marketplace parameters to "none" and use the full resource ID
 		azpublisher="none"
 		azoffer="none"
 		azsku="none"
 		azversion="none"
 		az_urn_sub=$gl_cloud_os_version
 	else
+		# Marketplace image using URN format (publisher:offer:sku:version)
+		# Parse the URN components
 		azpublisher=$(echo $gl_cloud_os_version | cut -f1 -d:)
 		azoffer=$(echo $gl_cloud_os_version | cut -f 2 -d:)
 		azsku=$(echo $gl_cloud_os_version | cut -f 3 -d:)

--- a/docs/burden-inputs.md
+++ b/docs/burden-inputs.md
@@ -113,7 +113,7 @@
 
 | Option | Arguments | Description |
 |--------|-----------|-------------|
-| <nobr>`--cloud_os_id`</nobr> | `<os_id>` | OS image ID (e.g., AWS AMI number). For multiple architectures:<br>`x86:ami-xxx,arm64:ami-yyy` |
+| <nobr>`--cloud_os_id`</nobr> | `<os_id>` | OS image ID. Format varies by cloud:<br>**AWS**: AMI ID or `x86:ami-xxx,arm64:ami-yyy`<br>**Azure**: URN (`publisher:offer:sku:version`) or resource ID<br>**GCP**: Image path |
 | <nobr>`--create_only`</nobr> | - | Only perform VM creation and OS installation, then stop |
 | <nobr>`--terminate_cloud`</nobr> | `0`/`1` | Terminate (1) or leave running (0) cloud instance. Default: 1 (terminate) |
 | <nobr>`--create_attempts`</nobr> | `<n>` | Number of attempts to create instance with designated CPU type. Default: 5 |

--- a/docs/command_line_reference.md
+++ b/docs/command_line_reference.md
@@ -196,10 +196,24 @@ Condensed usage information.
 ## Cloud-only options
 
 ## --cloud_os_id \<os id>
-Image of the OS to install (example aws aminumber)
-For multiple architectures, this is allowed"
-x86:ami-0fbec8a0a2beb6a71,arm64:ami-0cfa90ca3ebfc506e"
-Burden will select the right ami for the designated host."
+Image of the OS to install. Format varies by cloud provider:
+
+**AWS**: AMI ID or architecture-specific AMI IDs
+- Single architecture: `ami-0fbec8a0a2beb6a71`
+- Multiple architectures: `x86:ami-0fbec8a0a2beb6a71,arm64:ami-0cfa90ca3ebfc506e`
+  (Burden will select the right AMI for the designated host)
+
+**Azure**: Either marketplace URN or custom image resource ID
+- Marketplace image (URN format): `publisher:offer:sku:version`
+  - Example: `RedHat:RHEL:8-LVM:latest`
+  - Example: `Canonical:0001-com-ubuntu-server-focal:20_04-lts:latest`
+- Custom image from Azure Compute Gallery: `/subscriptions/{subscription-id}/resourceGroups/{rg}/providers/Microsoft.Compute/galleries/{gallery}/images/{image}/versions/{version}`
+  - Example: `/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myGalleryRG/providers/Microsoft.Compute/galleries/myGallery/images/rhel9-custom/versions/1.0.0`
+- Managed image: `/subscriptions/{subscription-id}/resourceGroups/{rg}/providers/Microsoft.Compute/images/{image-name}`
+  - Example: `/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myImagesRG/providers/Microsoft.Compute/images/rhel-9`
+
+**GCP**: Image name or full image path
+- Example: `projects/rhel-cloud/global/images/rhel-9-v20231010`
 
 ### --create_only
 Only do the VM creation and OS install action.

--- a/docs/testing_quickstart.md
+++ b/docs/testing_quickstart.md
@@ -117,12 +117,13 @@ Zathras supports automated provisioning and testing on major cloud providers.
 
 ### Azure Testing Example
 
+#### Using Marketplace Image (URN format)
 ```yaml
-# Example: azure_scenario
+# Example: azure_marketplace_scenario
 global:
     ssh_key_file: /home/user/.ssh/azure-key
     terminate_cloud: 1
-    cloud_os_id: /subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/images/rhel-9
+    cloud_os_id: RedHat:RHEL:8-LVM:latest
     os_vendor: rhel
     results_prefix: azure_fio_test
     system_type: azure
@@ -131,6 +132,26 @@ systems:
         tests: fio
         host_config: "Standard_D4s_v3:Disks;number=2;size=1000;type=Premium_LRS"
 ```
+
+#### Using Custom Image from Azure Compute Gallery
+```yaml
+# Example: azure_custom_image_scenario
+global:
+    ssh_key_file: /home/user/.ssh/azure-key
+    terminate_cloud: 1
+    cloud_os_id: /subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myGalleryRG/providers/Microsoft.Compute/galleries/myGallery/images/rhel9-custom/versions/1.0.0
+    os_vendor: rhel
+    results_prefix: azure_custom_test
+    system_type: azure
+systems:
+    system1:
+        tests: fio
+        host_config: "Standard_D4s_v3:Disks;number=2;size=1000;type=Premium_LRS"
+```
+
+**Note**: Azure supports two image source types:
+- **Marketplace images**: Use URN format `publisher:offer:sku:version` (e.g., `RedHat:RHEL:8-LVM:latest`)
+- **Custom images**: Use full resource ID path for Azure Compute Gallery images or Managed Images (must contain `/subscriptions/` in the path)
 
 ### GCP Testing Example
 


### PR DESCRIPTION
# Description
Adds support for booting azure private images (code is claude generated).

# Before/After Comparison
Before: Could not boot a private os image on Azure.
After:  Can boot a private os image on Azure.

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

# Clerical Stuff
This closes

Relates to JIRA: RPOPC-

Testing: 
Verified we still boot a non private OS image on Azure.
Verfied we can  boot a private OS image on Azure.