### PR TITLE
Fix aws output

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -50,6 +50,8 @@
 cli=${0}
 arguments=("$@")
 version="3.2"
+AWS_DEFAULT_OUTPUT="text"
+export AWS_DEFAULT_OUTPUT
 #
 # This bash script generates the test parameters to be used by ansible. End results
 # is an ansible data file called ansible_vars_main.yml containing the following

--- a/bin/burden
+++ b/bin/burden
@@ -354,12 +354,23 @@ cleanup_and_exit()
 	separ=""
 
 	if [[ -f $gl_tf_sys_list ]]; then
+		delete_tfs=""
 		while IFS= read -r run_data
 		do
-			delete_tfs="${delete_tfs}${separ}${run_data}"
-			separ=","
+			#
+			# Only if we have a running state for the vm
+			#
+			if [[ -d ${run_data}/terraform.tfstate.d ]]; then
+				grep -q "\"instance_state\": \"running\""  ${run_data}/tf//terraform.tfstate.d/*/terraform.tfstate 2> /dev/null
+				if [[ $? -eq 0 ]]; then
+					delete_tfs="${delete_tfs}${separ}${run_data}"
+					separ=","
+				fi
+			fi
 		done < $gl_tf_sys_list
-		$UTILS_DIR/terraform_ops --terminate_list "$delete_tfs"
+		if [[ $delete_tfs != "" ]]; then
+			$UTILS_DIR/terraform_ops --terminate_list "$delete_tfs"
+		fi
 	fi
 	rm -f $gl_cli_supplied_options $gl_run_info ${gl_run_info}.sorted $gl_tf_sys_list
 	#
@@ -2261,6 +2272,7 @@ create_ansible_options()
 			fi
 		fi
 	done
+
 	if [ $gl_preflight -ne 0 ]; then
 		echo Preflight complete
 		exit 0


### PR DESCRIPTION
# Description
1) Sets AWS_DEFAULT_OUTPUT to be text, so the output from the aws cli commands are as expected.
2) In cleanup_and_exit check to see if the instance exists before attempting to use terraform to terminate it.  Elienating a bogus error message.

# Before/After Comparison
Before:  If json was chose for the aws cli output, zathras will fail because the output is not in the proper format.  Also a bogus error message is put to the screen concerning attempting to delete the non-existent image.
After: The aws cli output is now in the expected format, and Zathras runs properly.  The bogus error message is no longer given if we exit out before the instance is actually created.

# Documentation Check
No

# Clerical Stuff
This closes #391 

JIRA: RPOPC-1236

Testing:
Verified the proper format is used regardless of the users default output.
Verified that the bogus error message no longer appears.
