### PR TITLE
fix: Allow for arm64 and aarch64 to be used interchangably

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -1459,6 +1459,12 @@ aws_specific_os_version()
 					break
 				fi
 			fi
+			# Clean up ambiguation between arm64 and aarch64
+			if [[ "${architecture}" == "arm64" ]] && [[ "$ami_value" == *"aarch64"* ]]; then
+				echo "  cloud_os_version: ${ami_check}" >> ansible_vars_main.yml
+				ami_found=1
+				break
+			fi
 		fi
 	done
 	if [[ $ami_found -eq 0 ]]; then


### PR DESCRIPTION
# Description
Allows AMI names to use arm64 or aarch64 for ARM runs.

# Before/After Comparison
## Before
AMIs had to have `arm64` in their name for ARM machines.

## After
AMIs can have `arm64` or `aarch64` in their name for ARM machines.

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

No doc changes needed.

# Clerical Stuff
This closes #394 

Relates to JIRA: RPOPC-1238
