### PR TITLE
Fix GCP CodeReady Builder dynamic repo detection for all RHEL versions and architectures

### DIFF
--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -232,112 +232,108 @@
     ansible.builtin.file:
       path: /tmp/cr_status
       state: absent
-  # TEMP: CodeReady Builder enable skipped (GCP/GCE experiments; re-enable when fixed).
-  # When this block is active again, set ten_of_us_codeready_cr_status_check: true on the
-  # local play "Terminate on repo failure" (cr_status) so missing-file false positives cannot occur.
-  # - name: install codeready repo (if RHEL)
-  #   block:
-  #   - name: Enable CodeReady Builder for AWS/Azure
-  #     block:
-  #     - name: get codeready repo name
-  #       shell:
-  #         cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
-  #       register: repo_name
-  #       ignore_errors: yes
-  #     - name: Record status of yum config success
-  #       include_role:
-  #         name: record_status
-  #       vars:
-  #         results: "{{ repo_name }}"
-  #         status_file: "/tmp/cr_status"
-  #     - name: aws upload the codeready repo
-  #       shell: "yum-config-manager --enable {{ repo_name.stdout }}"
-  #       register: yum_config
-  #       ignore_errors: yes
-  #     - name: Record status of yum config success
-  #       include_role:
-  #         name: record_status
-  #       vars:
-  #         results: "{{ yum_config }}"
-  #         status_file: "/tmp/cr_status"
-  #     when:
-  #       - config_info.system_type == "aws" or config_info.system_type == "azure"
-  #
-  #   - name: Enable CodeReady Builder for GCP
-  #     block:
-  #       - name: Install yum utils
-  #         become: yes
-  #         shell: "yum install yum-utils -y"
-  #
-  #       - name: get codeready repo name
-  #         shell:
-  #           cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
-  #         register: repo_name
-  #         ignore_errors: yes
-  #
-  #       - name: Record status of yum repolist success
-  #         include_role:
-  #           name: record_status
-  #         vars:
-  #           results: "{{ repo_name }}"
-  #           status_file: "/tmp/cr_status"
-  #
-  #       - name: Enable CodeReady Builder for GCP
-  #         shell: "yum-config-manager --enable {{ repo_name.stdout }}"
-  #         register: yum_config
-  #         ignore_errors: yes
-  #
-  #       - name: Record status of yum config success
-  #         include_role:
-  #           name: record_status
-  #         vars:
-  #           results: "{{ yum_config }}"
-  #           status_file: "/tmp/cr_status"
-  #     when:
-  #       - config_info.system_type == "gcp"
-  #       - config_info.do_not_install_packages == 0
-  #       - config_info.do_not_install_system_packages == 0
-  #
-  #   - name: Enable CodeReady Builder for IBM Cloud
-  #     block:
-  #       - name: Install yum utils
-  #         become: yes
-  #         shell: "yum install yum-utils -y"
-  #
-  #       - name: Enable CodeReady Builder for IBM Cloud
-  #         become: yes
-  #         shell: "yum-config-manager --enable codeready-builder-for-rhel-9-$(arch)-rpms"
-  #         register: yum_config
-  #         ignore_errors: yes
-  #
-  #       - name: Record status of yum config success
-  #         include_role:
-  #           name: record_status
-  #         vars:
-  #           results: "{{ yum_config }}"
-  #           status_file: "/tmp/cr_status"
-  #     when:
-  #       - config_info.system_type == "ibm"
-  #       - config_info.do_not_install_packages == 0
-  #       - config_info.do_not_install_system_packages == 0
-  #
-  #   - name: retrieve repo config status
-  #     include_role:
-  #       name: retrieve_status
-  #     vars:
-  #       status_file: "cr_status"
-  #     when:
-  #       - config_info.system_type != "local"
-  #   when:
-  #     - config_info.os_vendor == "rhel"
+  - name: install codeready repo (if RHEL)
+    block:
+    - name: Enable CodeReady Builder for AWS/Azure
+      block:
+      - name: get codeready repo name
+        shell:
+          cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
+        register: repo_name
+        ignore_errors: yes
+      - name: Record status of yum config success
+        include_role:
+          name: record_status
+        vars:
+          results: "{{ repo_name }}"
+          status_file: "/tmp/cr_status"
+      - name: aws upload the codeready repo
+        shell: "yum-config-manager --enable {{ repo_name.stdout }}"
+        register: yum_config
+        ignore_errors: yes
+      - name: Record status of yum config success
+        include_role:
+          name: record_status
+        vars:
+          results: "{{ yum_config }}"
+          status_file: "/tmp/cr_status"
+      when:
+        - config_info.system_type == "aws" or config_info.system_type == "azure"
+
+    - name: Enable CodeReady Builder for GCP
+      block:
+        - name: Install yum utils
+          become: yes
+          shell: "yum install yum-utils -y"
+
+        - name: get codeready repo name
+          shell:
+            cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
+          register: repo_name
+          ignore_errors: yes
+
+        - name: Record status of yum repolist success
+          include_role:
+            name: record_status
+          vars:
+            results: "{{ repo_name }}"
+            status_file: "/tmp/cr_status"
+
+        - name: Enable CodeReady Builder for GCP
+          shell: "yum-config-manager --enable {{ repo_name.stdout }}"
+          register: yum_config
+          ignore_errors: yes
+
+        - name: Record status of yum config success
+          include_role:
+            name: record_status
+          vars:
+            results: "{{ yum_config }}"
+            status_file: "/tmp/cr_status"
+      when:
+        - config_info.system_type == "gcp"
+        - config_info.do_not_install_packages == 0
+        - config_info.do_not_install_system_packages == 0
+
+    - name: Enable CodeReady Builder for IBM Cloud
+      block:
+        - name: Install yum utils
+          become: yes
+          shell: "yum install yum-utils -y"
+
+        - name: Enable CodeReady Builder for IBM Cloud
+          become: yes
+          shell: "yum-config-manager --enable codeready-builder-for-rhel-9-$(arch)-rpms"
+          register: yum_config
+          ignore_errors: yes
+
+        - name: Record status of yum config success
+          include_role:
+            name: record_status
+          vars:
+            results: "{{ yum_config }}"
+            status_file: "/tmp/cr_status"
+      when:
+        - config_info.system_type == "ibm"
+        - config_info.do_not_install_packages == 0
+        - config_info.do_not_install_system_packages == 0
+
+    - name: retrieve repo config status
+      include_role:
+        name: retrieve_status
+      vars:
+        status_file: "cr_status"
+      when:
+        - config_info.system_type != "local"
+    when:
+      - config_info.os_vendor == "rhel"
 
 - hosts: local
   vars_files: ansible_vars.yml
   gather_facts: no
   vars:
-    # False while CodeReady install + retrieve_status for cr_status is commented out above.
-    # Set true when that block is re-enabled so a real CodeReady failure is still caught.
-    ten_of_us_codeready_cr_status_check: false
+    # Set to true now that CodeReady Builder is re-enabled for testing
+    ten_of_us_codeready_cr_status_check: true
   tasks:
   - name: Terminate on repo failure
     include_role:

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -268,7 +268,7 @@
 
         - name: get codeready repo name
           shell:
-            cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
+            cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1 | head -1"
           register: repo_name
           ignore_errors: yes
 

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -316,7 +316,7 @@
       when:
         - config_info.system_type == "ibm"
         - config_info.do_not_install_packages == 0
-        - config_info.do_not_install_system_packages == 0
+        - config_info.config_info.do_not_install_system_packages == 0
 
     - name: retrieve repo config status
       include_role:

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -232,7 +232,9 @@
     ansible.builtin.file:
       path: /tmp/cr_status
       state: absent
-  # TEMP: CodeReady Builder enable skipped (GCP/GCE experiments; re-enable when fixed)
+  # TEMP: CodeReady Builder enable skipped (GCP/GCE experiments; re-enable when fixed).
+  # When this block is active again, set ten_of_us_codeready_cr_status_check: true on the
+  # local play "Terminate on repo failure" (cr_status) so missing-file false positives cannot occur.
   # - name: install codeready repo (if RHEL)
   #   block:
   #   - name: Enable CodeReady Builder for AWS/Azure
@@ -334,6 +336,10 @@
 - hosts: local
   vars_files: ansible_vars.yml
   gather_facts: no
+  vars:
+    # False while CodeReady install + retrieve_status for cr_status is commented out above.
+    # Set true when that block is re-enabled so a real CodeReady failure is still caught.
+    ten_of_us_codeready_cr_status_check: false
   tasks:
   - name: Terminate on repo failure
     include_role:
@@ -341,7 +347,10 @@
     vars:
       status_file: "cr_status"
       exit_msg: "Code repo installation failure"
-    when: (config_info.os_vendor == "rhel") and (config_info.system_type == "aws" or config_info.system_type == "azure" or config_info.system_type == "gcp")
+    when:
+      - ten_of_us_codeready_cr_status_check | bool
+      - config_info.os_vendor == "rhel"
+      - config_info.system_type == "aws" or config_info.system_type == "azure" or config_info.system_type == "gcp"
 
 #
 # Enable SLES legacy module

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -265,27 +265,25 @@
   #
   #   - name: Enable CodeReady Builder for GCP
   #     block:
-  #
   #       - name: Install yum utils
   #         become: yes
   #         shell: "yum install yum-utils -y"
   #
-  #       #- name: get codeready repo name
-  #       #  shell:
-  #       #    cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
-  #       #    warn: false
-  #       #    register: repo_name
-  #       #    ignore_errors: yes
-  #       #- name: Record status of yum config success
-  #       #  include_role:
-  #       #    name: record_status
-  #       #  vars:
-  #       #    results: "{{ repo_name }}"
-  #       #   status_file: "/tmp/cr_status"
+  #       - name: get codeready repo name
+  #         shell:
+  #           cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
+  #         register: repo_name
+  #         ignore_errors: yes
+  #
+  #       - name: Record status of yum repolist success
+  #         include_role:
+  #           name: record_status
+  #         vars:
+  #           results: "{{ repo_name }}"
+  #           status_file: "/tmp/cr_status"
   #
   #       - name: Enable CodeReady Builder for GCP
-  #         become: yes
-  #         shell: "yum-config-manager --enable rhui-codeready-builder-for-rhel-9-x86_64-rhui-rpms"
+  #         shell: "yum-config-manager --enable {{ repo_name.stdout }}"
   #         register: yum_config
   #         ignore_errors: yes
   #

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -232,103 +232,104 @@
     ansible.builtin.file:
       path: /tmp/cr_status
       state: absent
-  - name: install codeready repo (if RHEL)
-    block:
-    - name: Enable CodeReady Builder for AWS/Azure
-      block:
-      - name: get codeready repo name
-        shell:
-          cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
-        register: repo_name
-        ignore_errors: yes
-      - name: Record status of yum config success
-        include_role:
-          name: record_status
-        vars:
-          results: "{{ repo_name }}"
-          status_file: "/tmp/cr_status"
-      - name: aws upload the codeready repo
-        shell: "yum-config-manager --enable {{ repo_name.stdout }}"
-        register: yum_config
-        ignore_errors: yes
-      - name: Record status of yum config success
-        include_role:
-          name: record_status
-        vars:
-          results: "{{ yum_config }}"
-          status_file: "/tmp/cr_status"
-      when:
-        - config_info.system_type == "aws" or config_info.system_type == "azure"
-
-    - name: Enable CodeReady Builder for GCP
-      block:
-
-        - name: Install yum utils
-          become: yes
-          shell: "yum install yum-utils -y"
-
-        #- name: get codeready repo name
-        #  shell:
-        #    cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
-        #    warn: false
-        #    register: repo_name
-        #    ignore_errors: yes
-        #- name: Record status of yum config success
-        #  include_role:
-        #    name: record_status
-        #  vars:
-        #    results: "{{ repo_name }}"
-        #   status_file: "/tmp/cr_status"
-
-        - name: Enable CodeReady Builder for GCP
-          become: yes
-          shell: "yum-config-manager --enable rhui-codeready-builder-for-rhel-9-x86_64-rhui-rpms"
-          register: yum_config
-          ignore_errors: yes
-
-        - name: Record status of yum config success
-          include_role:
-            name: record_status
-          vars:
-            results: "{{ yum_config }}"
-            status_file: "/tmp/cr_status"
-      when:
-        - config_info.system_type == "gcp"
-        - config_info.do_not_install_packages == 0
-        - config_info.config_info.do_not_install_system_packages == 0
-
-    - name: Enable CodeReady Builder for IBM Cloud
-      block:
-        - name: Install yum utils
-          become: yes
-          shell: "yum install yum-utils -y"
-
-        - name: Enable CodeReady Builder for IBM Cloud
-          become: yes
-          shell: "yum-config-manager --enable codeready-builder-for-rhel-9-$(arch)-rpms"
-          register: yum_config
-          ignore_errors: yes
-
-        - name: Record status of yum config success
-          include_role:
-            name: record_status
-          vars:
-            results: "{{ yum_config }}"
-            status_file: "/tmp/cr_status"
-      when:
-        - config_info.system_type == "ibm"
-        - config_info.do_not_install_packages == 0
-        - config_info.config_info.do_not_install_system_packages == 0
-
-    - name: retrieve repo config status
-      include_role:
-        name: retrieve_status
-      vars:
-        status_file: "cr_status"
-      when:
-        - config_info.system_type != "local"
-    when:
-      - config_info.os_vendor == "rhel"
+  # TEMP: CodeReady Builder enable skipped (GCP/GCE experiments; re-enable when fixed)
+  # - name: install codeready repo (if RHEL)
+  #   block:
+  #   - name: Enable CodeReady Builder for AWS/Azure
+  #     block:
+  #     - name: get codeready repo name
+  #       shell:
+  #         cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
+  #       register: repo_name
+  #       ignore_errors: yes
+  #     - name: Record status of yum config success
+  #       include_role:
+  #         name: record_status
+  #       vars:
+  #         results: "{{ repo_name }}"
+  #         status_file: "/tmp/cr_status"
+  #     - name: aws upload the codeready repo
+  #       shell: "yum-config-manager --enable {{ repo_name.stdout }}"
+  #       register: yum_config
+  #       ignore_errors: yes
+  #     - name: Record status of yum config success
+  #       include_role:
+  #         name: record_status
+  #       vars:
+  #         results: "{{ yum_config }}"
+  #         status_file: "/tmp/cr_status"
+  #     when:
+  #       - config_info.system_type == "aws" or config_info.system_type == "azure"
+  #
+  #   - name: Enable CodeReady Builder for GCP
+  #     block:
+  #
+  #       - name: Install yum utils
+  #         become: yes
+  #         shell: "yum install yum-utils -y"
+  #
+  #       #- name: get codeready repo name
+  #       #  shell:
+  #       #    cmd: "yum repolist --all|grep -i codeready|grep -v -i debug |grep -v -i source | cut -d' ' -f 1"
+  #       #    warn: false
+  #       #    register: repo_name
+  #       #    ignore_errors: yes
+  #       #- name: Record status of yum config success
+  #       #  include_role:
+  #       #    name: record_status
+  #       #  vars:
+  #       #    results: "{{ repo_name }}"
+  #       #   status_file: "/tmp/cr_status"
+  #
+  #       - name: Enable CodeReady Builder for GCP
+  #         become: yes
+  #         shell: "yum-config-manager --enable rhui-codeready-builder-for-rhel-9-x86_64-rhui-rpms"
+  #         register: yum_config
+  #         ignore_errors: yes
+  #
+  #       - name: Record status of yum config success
+  #         include_role:
+  #           name: record_status
+  #         vars:
+  #           results: "{{ yum_config }}"
+  #           status_file: "/tmp/cr_status"
+  #     when:
+  #       - config_info.system_type == "gcp"
+  #       - config_info.do_not_install_packages == 0
+  #       - config_info.do_not_install_system_packages == 0
+  #
+  #   - name: Enable CodeReady Builder for IBM Cloud
+  #     block:
+  #       - name: Install yum utils
+  #         become: yes
+  #         shell: "yum install yum-utils -y"
+  #
+  #       - name: Enable CodeReady Builder for IBM Cloud
+  #         become: yes
+  #         shell: "yum-config-manager --enable codeready-builder-for-rhel-9-$(arch)-rpms"
+  #         register: yum_config
+  #         ignore_errors: yes
+  #
+  #       - name: Record status of yum config success
+  #         include_role:
+  #           name: record_status
+  #         vars:
+  #           results: "{{ yum_config }}"
+  #           status_file: "/tmp/cr_status"
+  #     when:
+  #       - config_info.system_type == "ibm"
+  #       - config_info.do_not_install_packages == 0
+  #       - config_info.do_not_install_system_packages == 0
+  #
+  #   - name: retrieve repo config status
+  #     include_role:
+  #       name: retrieve_status
+  #     vars:
+  #       status_file: "cr_status"
+  #     when:
+  #       - config_info.system_type != "local"
+  #   when:
+  #     - config_info.os_vendor == "rhel"
 
 - hosts: local
   vars_files: ansible_vars.yml


### PR DESCRIPTION

[ansible_log_after.txt](https://github.com/user-attachments/files/28641308/ansible_log_after.txt)
[ansible_log_before.txt](https://github.com/user-attachments/files/28641309/ansible_log_before.txt)
# Description

Fixes the GCP CodeReady Builder repository setup to use dynamic detection instead of hardcoded RHEL version and architecture. This enables GCP tests to run successfully on all RHEL versions (8, 9, 10+) and all architectures (x86_64, aarch64).

The existing AWS/Azure implementation already used dynamic detection. This PR brings GCP to parity with that approach, making the implementation consistent across cloud providers.

# Before/After Comparison

## Before

GCP CodeReady Builder setup was hardcoded to RHEL 9 x86_64:
```yaml
shell: "yum-config-manager --enable rhui-codeready-builder-for-rhel-9-x86_64-rhui-rpms"
```

From ansible_log_before:
```
TASK [aws upload the codeready repo] *******************************************
skipping: [104.197.60.234]

TASK [Record status of yum config success] *************************************
skipping: [104.197.60.234]

TASK [Install yum utils] *******************************************************
fatal: [104.197.60.234]: FAILED! => {"msg": "The conditional check 'config_info.config_info.do_not_install_system_packages == 0' failed. The error was: error while evaluating conditional (config_info.config_info.do_not_install_system_packages == 0): 'dict object' has no attribute 'config_info'. 'dict object' has no attribute 'config_info'\n\nThe error appears to be in '/home/gdumas/debug-gcp-crb-broken/rhel-10/rhel/gcp/c4a-standard-8_0/ten_of_us.yml': line 266, column 11, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n        - name: Install yum utils\n          ^ here\n"}

PLAY RECAP *********************************************************************
104.197.60.234             : ok=16   changed=9    unreachable=0    failed=1    skipped=12   rescued=0    ignored=0
localhost                  : ok=53   changed=34   unreachable=0    failed=0    skipped=23   rescued=0    ignored=0

Error: test started, system died.
```

**Issues:**
- Failed on RHEL 8 systems (repo not found)
- Failed on RHEL 10 systems (repo not found)
- Failed on aarch64/ARM systems (repo not found)
- Entire CodeReady Builder feature was disabled with "TEMP: experiments" comment

## After

GCP now dynamically detects the correct CodeReady Builder repo. From ansible_log_after:
```TASK [get codeready repo name] *************************************************
skipping: [34.68.96.178]

TASK [Record status of yum config success] *************************************
skipping: [34.68.96.178]

TASK [aws upload the codeready repo] *******************************************
skipping: [34.68.96.178]

TASK [Record status of yum config success] *************************************
skipping: [34.68.96.178]

TASK [Install yum utils] *******************************************************
changed: [34.68.96.178]

TASK [get codeready repo name] *************************************************
changed: [34.68.96.178]

TASK [Record status of yum repolist success] ***********************************

TASK [record_status : Record status of run success] ****************************
changed: [34.68.96.178]

TASK [record_status : Record status of run failure] ****************************
skipping: [34.68.96.178]

TASK [Enable CodeReady Builder for GCP] ****************************************
changed: [34.68.96.178]

TASK [Record status of yum config success] *************************************

TASK [record_status : Record status of run success] ****************************
ok: [34.68.96.178]

TASK [record_status : Record status of run failure] ****************************
skipping: [34.68.96.178]

TASK [Install yum utils] *******************************************************
skipping: [34.68.96.178]
```

**Results:**
- CodeReady Builder step now succeeds for GCP runs beyond just RHEL 9 x86_64 runs. 
- Works on RHEL 8 (x86_64, aarch64)
- Works on RHEL 9 (x86_64, aarch64)
- Works on RHEL 10 (x86_64, aarch64)

## Key Changes

1. **Dynamic repo detection** - Uses `yum repolist` to discover the correct repo name instead of hardcoding
2. **Multi-match handling** - Added `head -1` to handle RHEL 8 cases where multiple repos are returned
3. **Status tracking** - Added proper status recording for repo discovery step
4. **Code cleanup** - Removed commented-out failed attempts at dynamic detection
5. **Feature enabled** - Uncommented entire CodeReady Builder section and set `ten_of_us_codeready_cr_status_check: true`

# Documentation Check

Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

No documentation changes needed. This is an internal infrastructure fix that makes existing functionality work correctly. The CodeReady Builder setup is handled automatically by the Ansible playbook.

# Clerical Stuff

This PR addresses the GCP CodeReady Builder issue discovered during testing.
Closes #397
Relates to JIRA: RPOPC-1246

**Testing completed:**
- GCP RHEL 8/9/10 x86_64: Passed
- GCP RHEL 8/9/10 aarch64: Passed

**Note:** AWS and Azure may have the same RHEL 8 multi-match issue and should be addressed in a separate PR/issue.

PR drafted with Claude, edited and reviewed by human.


