### PR TITLE
fix: Add random suffix to Azure resource group names to prevent collisions

### DIFF
--- a/ansible_roles/roles/azure_create/files/tf/main_net_p1.tf
+++ b/ansible_roles/roles/azure_create/files/tf/main_net_p1.tf
@@ -4,6 +4,10 @@ terraform {
       source = "hashicorp/azurerm"
       version = "~>2.0"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "~>3.0"
+    }
   }
 }
 provider "azurerm" {
@@ -11,9 +15,13 @@ provider "azurerm" {
   subscription_id = var.az_subscription
 }
 
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 # Define resource group
 resource "azurerm_resource_group" "resource_group" {
-    name     = var.resource_group
+    name     = "${var.resource_group}-${random_id.suffix.hex}"
     location = var.location
     tags     = local.tags
 }

--- a/ansible_roles/roles/azure_create/files/tf/main_no_net.tf
+++ b/ansible_roles/roles/azure_create/files/tf/main_no_net.tf
@@ -4,6 +4,10 @@ terraform {
       source = "hashicorp/azurerm"
       version = "~>2.0"
     }
+    random = {
+      source = "hashicorp/random"
+      version = "~>3.0"
+    }
   }
 }
 provider "azurerm" {
@@ -11,8 +15,12 @@ provider "azurerm" {
   subscription_id = var.az_subscription
 }
 
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
 resource "azurerm_resource_group" "resource_group" {
-    name     = var.resource_group
+    name     = "${var.resource_group}-${random_id.suffix.hex}"
     location = var.location
     tags     = local.tags
 }

--- a/ansible_roles/roles/azure_create/files/tf/output_net.tf
+++ b/ansible_roles/roles/azure_create/files/tf/output_net.tf
@@ -5,3 +5,6 @@ output "public_ip_address" {
 output "internal_ip_list" {
  value = data.azurerm_network_interface.testnic1[*].private_ip_address
 }
+output "resource_group_name" {
+ value = azurerm_resource_group.resource_group.name
+}

--- a/ansible_roles/roles/azure_create/files/tf/output_no_net.tf
+++ b/ansible_roles/roles/azure_create/files/tf/output_no_net.tf
@@ -2,3 +2,6 @@
 output "public_ip_address" {
  value = data.azurerm_public_ip.publicip[*].ip_address
 }
+output "resource_group_name" {
+ value = azurerm_resource_group.resource_group.name
+}


### PR DESCRIPTION
## Summary

- Adds `hashicorp/random` provider and a `random_id` resource to generate a unique 8-character hex suffix for Azure resource group names
- Applies the suffix in both networking (`main_net_p1.tf`) and non-networking (`main_no_net.tf`) Terraform configs
- Exports the actual resource group name via a new `resource_group_name` Terraform output in both `output_net.tf` and `output_no_net.tf`

## Problem

When multiple Azure systems are created simultaneously (e.g., via a multi-system scenario), they all try to create a resource group with the same deterministic name, causing Terraform to fail with:

> `"already exists - to be managed via Terraform this resource needs to be imported into the State"`

## Solution

Append a random hex suffix (`random_id.suffix.hex`) to the resource group name so each concurrent Terraform run creates a uniquely named resource group. The actual name is exported as a Terraform output for downstream consumers.

## Test plan

- [x] Verified with two concurrent Azure `streams` systems using `Standard_D16s_v5` — both got unique resource groups (`*-9f8cbbfa` and `*-3b8e7863`), VMs provisioned, tests completed, and teardown succeeded
- [x] Confirmed `random_id.suffix` appears in Terraform plan
- [x] Confirmed `resource_group_name` output is populated after apply

Fixes #389
Relates to JIRA: RPOPC-1220