### PR TITLE
feat: Add ssh_pub_key_file option for specifying SSH public key

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -79,6 +79,7 @@ version="3.2"
 #   update_type: what is the update repository (example ftp, iso).
 #   gl_persistent_log: enable persistent logging
 #   gl_ssh_key_file: Points to the ssh config file we are to use.  If not set, we will not use one.
+#   gl_ssh_pub_key_file: Points to the ssh public key file.  If not set, we will not use one.
 #   gl_java_version: Version of Java to load: currently java-8, java-11, java-17, or java-21
 #   gl_rhel_tuned_setting: tuned configuration to use
 #   gl_cloud_execute_tests: If set to 1, we will execute test on the cloud image, else
@@ -187,6 +188,7 @@ gl_selinux_level="enforcing"
 gl_selinux_state=$value_not_set
 gl_selinux_state_set=0
 gl_ssh_key_file=""
+gl_ssh_pub_key_file=""
 gl_show_os_versions=0;
 gl_test_def_file=""
 gl_test_def_dir="${gl_top_dir}/config"
@@ -1916,6 +1918,11 @@ create_ansible_options()
 		else
 			echo "  ssh_key: ${gl_ssh_key_file}" >> ansible_vars_main.yml
 		fi
+		if [[ $gl_ssh_pub_key_file == "" ]]; then
+			echo "  ssh_pub_key: none_designated" >> ansible_vars_main.yml
+		else
+			echo "  ssh_pub_key: ${gl_ssh_pub_key_file}" >> ansible_vars_main.yml
+		fi
 		#
 		# local system type, user is expected to be root. cloud systems are expected
 		# to be non-root.
@@ -2043,6 +2050,9 @@ create_ansible_options()
 			base_string="-t $gl_top_dir -d $run_dir -f $gl_sys_file -a $gl_create_attempts -S $gl_spot_recover -c $gl_test_def_dir"
 			if [[ "$gl_ssh_key_file" != "" ]]; then
 				base_string="${base_string} -s $gl_ssh_key_file"
+			fi
+			if [[ "$gl_ssh_pub_key_file" != "" ]]; then
+				base_string="${base_string} -p $gl_ssh_pub_key_file"
 			fi
 			if [[ $gl_ansible_verbosity != "normal" ]]; then
 				base_string=${base_string}" -l $gl_ansible_verbosity"
@@ -3346,7 +3356,8 @@ usage()
 	echo "  --scenario_vars <file>: file that contains the variables for the scenario file. The default is config/zathras_scenario_vars_def."
 	echo "  --selinux_level: enforcing/permissive/disabled"
 	echo "  --selinux_state: disabled/enabled"
-	echo "  --ssh_key_file: Designates the ssh key file we are to use."
+	echo "  --ssh_key_file: Designates the ssh private key file we are to use."
+	echo "  --ssh_pub_key_file: Designates the ssh public key file we are to use."
 	echo "  --show_os_versions: given the cloud type, and OS vendor, show the available os versions"
 	echo "  --show_tests:  list the available test as defined in config/test_defs.yml"
 	echo "  --test_def_file <file>: test definition file to use."
@@ -3356,6 +3367,7 @@ usage()
 	echo "    Example:"
 	echo "      global:"
 	echo "        ssh_key_file: /home/test_user/permissions/aws_region_2_ssh_key"
+	echo "        ssh_pub_key_file: /home/test_user/permissions/aws_region_2_ssh_key.pub"
 	echo "        terminate_cloud: 1"
 	echo "        cloud_os_id: aminumber"
 	echo "        os_vendor: rhel"
@@ -3653,6 +3665,14 @@ set_general_value()
 			fi
 			shift_by=2
 		;;
+		--ssh_pub_key_file)
+			if [[ $gl_ssh_pub_key_file == "" ]]; then
+				echo "$1 $2" >> $gl_cli_supplied_options
+				gl_ssh_pub_key_file=$2
+				verify_data verify_ssh_key_file $gl_ssh_pub_key_file
+			fi
+			shift_by=2
+		;;
 		--system_type)
 			if [[ $gl_system_type == "" ]]; then
 				echo "$1 $2" >> $gl_cli_supplied_options
@@ -3830,6 +3850,7 @@ grab_cli_data()
 		"run_file"
 		"scenario"
 		"ssh_key_file"
+		"ssh_pub_key_file"
 		"tuned_profiles"
 		"scenario_vars"
 		"selinux_level"

--- a/bin/kick_off.sh
+++ b/bin/kick_off.sh
@@ -99,8 +99,9 @@ report_usage()
 spot_recover=1
 create_attempts=5
 ssh_key_file=""
+ssh_pub_key_file=""
 ansible_noise_level="normal"
-while getopts "a:c:d:f:s:S:t:l:" o; do
+while getopts "a:c:d:f:p:s:S:t:l:" o; do
         case "${o}" in
 		a)
 			create_attempts=${OPTARG}
@@ -116,6 +117,9 @@ while getopts "a:c:d:f:s:S:t:l:" o; do
 		;;
 		l)
 			ansible_noise_level=${OPTARG}
+		;;
+		p)
+			ssh_pub_key_file=${OPTARG}
 		;;
 		S)
 			spot_recover=${OPTARG}
@@ -162,6 +166,14 @@ if [[ $ssh_key_file != "" ]]; then
 	fi
 	chmod 500 config/user.pem_test
 fi
+if [[ $ssh_pub_key_file != "" ]]; then
+	cp $ssh_pub_key_file config/user.pub_test
+	if [ ! -s $ssh_pub_key_file ]; then
+		echo "${ssh_pub_key_file} is zero length, please fix.  Test is exiting"
+		exit 1
+	fi
+	chmod 400 config/user.pub_test
+fi
 
 #
 # figure out how many files we have to set /proc/* etc. This allows us to only terminate the
@@ -179,6 +191,9 @@ remove_perm_file()
 {
 	if [[ $ssh_key_file != "" ]]; then
 		rm -f config/user.pem_test
+	fi
+	if [[ $ssh_pub_key_file != "" ]]; then
+		rm -f config/user.pub_test
 	fi
 }
 

--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -65,6 +65,14 @@
       set_fact:
         dash_i_value: "ssh_i_option: \"\""
       when: config_info.ssh_key == "none_designated"
+    - name: set ssh public key file
+      set_fact:
+        ssh_pub_key_value: "ssh_pub_key_option: \"{{ config_info.ssh_pub_key }}\""
+      when: config_info.ssh_pub_key is defined and config_info.ssh_pub_key != "none_designated"
+    - name: No ssh public key file designated, default null string.
+      set_fact:
+        ssh_pub_key_value: "ssh_pub_key_option: \"\""
+      when: config_info.ssh_pub_key is not defined or config_info.ssh_pub_key == "none_designated"
 
 #
 # Preset the tf.rtc file
@@ -89,6 +97,12 @@
       lineinfile:
         path: "{{ working_dir }}/ansible_run_vars.yml"
         line: "{{ dash_i_value }}"
+        create: yes
+
+    - name: add the ssh public key line to the file
+      lineinfile:
+        path: "{{ working_dir }}/ansible_run_vars.yml"
+        line: "{{ ssh_pub_key_value }}"
         create: yes
 
     - name: aws operations


### PR DESCRIPTION
## Summary
- Adds `ssh_pub_key_file` option to allow specifying both public and private SSH keys
- Supports both scenario YAML (`ssh_pub_key_file: /path/to/key.pub`) and CLI flag (`--ssh_pub_key_file /path/to/key.pub`)
- Fully backward compatible — when not specified, behavior is unchanged

## Changes
- `bin/burden`: New `gl_ssh_pub_key_file` variable, CLI parsing, ARGUMENT_LIST entry, ansible vars generation, passthrough to kick_off.sh
- `bin/kick_off.sh`: New `-p` getopts flag, public key copy/validate/cleanup
- `bin/ten_of_us.yml`: New `ssh_pub_key_option` fact and ansible_run_vars.yml entry

## Test plan
- [ ] Run with scenario containing both `ssh_key_file` and `ssh_pub_key_file`
- [ ] Run with scenario containing only `ssh_key_file` (backward compat)
- [ ] Verify `ansible_vars_main.yml` contains `ssh_pub_key` entry
- [ ] Verify `ansible_run_vars.yml` contains `ssh_pub_key_option` entry