### PR TITLE
Fix Terraform apply and Propogate Ansible Exit codes

### DIFF
--- a/ansible_roles/roles/tf_create/tasks/tf_apply.yml
+++ b/ansible_roles/roles/tf_create/tasks/tf_apply.yml
@@ -25,4 +25,4 @@
     regexp: '^(.*)rtc:(.*)$'
     line: "rtc: 0"
     backrefs: yes
-  when: create.rc == 0 and '"Error" not in create.stdout_lines' and '"Error" not in create.stdout'
+  when: create.rc == 0 and "Error" not in create.stdout_lines and "Error" not in create.stdout

--- a/ansible_roles/roles/tf_create/tasks/tf_apply.yml
+++ b/ansible_roles/roles/tf_create/tasks/tf_apply.yml
@@ -13,16 +13,24 @@
   debug:
     var: create
 
+- name: Determine if terraform succeeded
+  ansible.builtin.set_fact:
+    tf_success: '{{ create.rc == 0 and "Error" not in create.stdout_lines and "Error" not in create.stdout }}'
+
 #
 # update the return status, to be used by the calling module.  We could
 # use set facts here, but chose to use a file instead for debugging purposes.
 # We can not write directly out the rtc, because spot returns ok, even
 # when it failed. So we need to check.
 #
-- name: Save the tf operation return code, success
+- name: Save the tf operation return code
   lineinfile:
     path: "{{ working_dir }}/tf.rtc"
     regexp: '^(.*)rtc:(.*)$'
-    line: "rtc: 0"
+    line: "rtc: {{ '0' if tf_success else '1' }}"
     backrefs: yes
-  when: create.rc == 0 and "Error" not in create.stdout_lines and "Error" not in create.stdout
+
+- name: Fail if terraform failed
+  when: not tf_success
+  ansible.builtin.fail:
+    msg: "Terraform failure"

--- a/ansible_roles/roles/tf_create/tasks/tf_apply.yml
+++ b/ansible_roles/roles/tf_create/tasks/tf_apply.yml
@@ -2,7 +2,7 @@
 
 - name: Create resources
   shell: |
-    set -o pipefail
+    set -eo pipefail
     terraform workspace select {{ config_info.system_type }}-{{ config_info.run_label }}-{{ config_info.host_or_cloud_inst }}
     terraform apply plan.tfplan 2>&1 | tee {{ working_dir }}/tf/terraform_apply.out
   args:

--- a/ansible_roles/roles/tf_create/tasks/tf_apply.yml
+++ b/ansible_roles/roles/tf_create/tasks/tf_apply.yml
@@ -2,10 +2,12 @@
 
 - name: Create resources
   shell: |
+    set -o pipefail
     terraform workspace select {{ config_info.system_type }}-{{ config_info.run_label }}-{{ config_info.host_or_cloud_inst }}
     terraform apply plan.tfplan 2>&1 | tee {{ working_dir }}/tf/terraform_apply.out
   args:
     chdir: "{{ working_dir }}/tf"
+    executable: /bin/bash
   register: create
   ignore_errors: yes
 
@@ -15,7 +17,7 @@
 
 - name: Determine if terraform succeeded
   ansible.builtin.set_fact:
-    tf_success: '{{ create.rc == 0 and "Error" not in create.stdout_lines and "Error" not in create.stdout }}'
+    tf_success: '{{ create.rc == 0 }}'
 
 #
 # update the return status, to be used by the calling module.  We could

--- a/bin/burden
+++ b/bin/burden
@@ -4535,7 +4535,7 @@ fi
 if [[ $gl_scenario_to_run != "" ]]; then
         run_scenario $gl_scenario_to_run
 	process_results
-        cleanup_and_exit "" 0
+        cleanup_and_exit "" $gl_ansible_failed
 fi
 
 #

--- a/bin/burden
+++ b/bin/burden
@@ -232,6 +232,7 @@ gl_bootc_mode=0
 gl_cpu_type_request="none"
 gl_run_file=""
 gl_failed_test_rpt="failed_tests"
+gl_ansible_failed=0
 
 #
 # Make sure the lock directory exists
@@ -293,6 +294,9 @@ wait_for_procs()
 		out_string=`echo $pid | cut -d ':' -f 2-`
 		wait_for=`echo $pid | cut -d ':' -f 1`
 		wait $wait_for
+		if [ $? -ne 0 ]; then
+			gl_ansible_failed=1
+		fi
 		echo Finished $out_string
 	done
 }
@@ -2241,13 +2245,13 @@ create_ansible_options()
 				# Do not allow simultaneous runs to the same local host.
 				#
 				touch $gl_top_dir/lock_dir/${host_or_cloud_inst}
-				flock -x $gl_top_dir/lock_dir/${host_or_cloud_inst} kick_off.sh $base_string | tee ${run_dir}/ansible_log &
+				flock -x $gl_top_dir/lock_dir/${host_or_cloud_inst} kick_off.sh $base_string > >(tee ${run_dir}/ansible_log) &
 			else
 				#
 				# Cloud does not require exclusive locks on execution
 				# as we create a new cloud image.
 				#
-				kick_off.sh $base_string | tee ${run_dir}/ansible_log &
+				kick_off.sh $base_string > >(tee ${run_dir}/ansible_log) &
 			fi
 			rpid=$!
 			gl_run_pids[${gl_run_pindex}]="${rpid}:${test_info_str} on ${host_or_cloud_inst}"
@@ -4620,4 +4624,4 @@ fi
 
 process_results
 popd > /dev/null
-cleanup_and_exit "" 0
+cleanup_and_exit "" $gl_ansible_failed

--- a/bin/kick_off.sh
+++ b/bin/kick_off.sh
@@ -21,6 +21,7 @@
 
 top_dir=`pwd`
 ans_pid="0"
+ans_rtc=0
 
 cleanup_and_exit()
 {
@@ -230,6 +231,7 @@ do
 		ansible-playbook -i ./inventory --extra-vars "working_dir=${curdir} ansible_python_interpreter=/usr/bin/python3 delete_tf=none" ten_of_us.yml &
 		ans_pid=$!
 		wait $ans_pid
+		ans_rtc=$?
 		ans_pid=0
 		#
 		if [ $spot_recover -eq 1 ] && [[ ! -f "test_returned" ]] && [[ ! -f "cpu_type_failure" ]]; then
@@ -310,4 +312,4 @@ rm -f *status
 # Remove  misc files
 #
 rm -rf terraform_data.yml test_info upload* ignore.yml tags_defaults ansible.cfg config ansible_install_group add_vars_tf add_main_vars.tf add_main_tf_vars ansible_test_group
-exit 0
+exit $ans_rtc


### PR DESCRIPTION
# Description
This PR fixes Terraform erroring out on apply.  This also propogates ansible exit codes to burden for CI purposes

# Before/After Comparison
## Before
If terraform failed to apply, it would teardown normally, and then exit with a success exit code.

## After
If terraform fails to apply, it will teardown normally, and give a non-zero exit code.  Ansible exit codes will propogate to burden invocations

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?


No docs needed.
# Clerical Stuff
This closes #403 

Relates to JIRA: RPOPC-1266
