### PR TITLE
fix: Derive Azure SSH pub key path from private key when not set (#420)

### DIFF
--- a/ansible_roles/roles/azure_create/files/tf/main_net_p2_sub.tf
+++ b/ansible_roles/roles/azure_create/files/tf/main_net_p2_sub.tf
@@ -10,7 +10,7 @@ resource "azurerm_linux_virtual_machine" "virtualmachine" {
 
     admin_ssh_key {
         username   = var.test_user
-        public_key = file(var.ssh_pub_key_path)
+        public_key = file(local.ssh_pub_key_path)
     }
     PRIORITYSPOT
     EVICTIONPOLICY

--- a/ansible_roles/roles/azure_create/files/tf/main_net_p2_urn.tf
+++ b/ansible_roles/roles/azure_create/files/tf/main_net_p2_urn.tf
@@ -10,7 +10,7 @@ resource "azurerm_linux_virtual_machine" "virtualmachine" {
 
     admin_ssh_key {
         username   = var.test_user
-        public_key = file(var.ssh_pub_key_path)
+        public_key = file(local.ssh_pub_key_path)
     }
     PRIORITYSPOT
     EVICTIONPOLICY

--- a/ansible_roles/roles/azure_create/files/tf/vars.tf
+++ b/ansible_roles/roles/azure_create/files/tf/vars.tf
@@ -52,6 +52,10 @@ variable "ssh_pub_key_path" {
   default = ""
 }
 
+locals {
+  ssh_pub_key_path = var.ssh_pub_key_path != "" ? var.ssh_pub_key_path : "${var.ssh_key_path}.pub"
+}
+
 variable "vm_image" {
   type    = string
   default = "none"

--- a/ansible_roles/roles/azure_create/files/tf/vm_spot_set_sub.tf
+++ b/ansible_roles/roles/azure_create/files/tf/vm_spot_set_sub.tf
@@ -9,7 +9,7 @@ resource "azurerm_linux_virtual_machine" "virtualmachine" {
     admin_username        = var.test_user
     admin_ssh_key {
         username   = var.test_user
-        public_key = file(var.ssh_pub_key_path)
+        public_key = file(local.ssh_pub_key_path)
     }
     PRIORITYSPOT
     EVICTIONPOLICY

--- a/ansible_roles/roles/azure_create/files/tf/vm_spot_set_urn.tf
+++ b/ansible_roles/roles/azure_create/files/tf/vm_spot_set_urn.tf
@@ -9,7 +9,7 @@ resource "azurerm_linux_virtual_machine" "virtualmachine" {
     admin_username        = var.test_user
     admin_ssh_key {
         username   = var.test_user
-        public_key = file(var.ssh_pub_key_path)
+        public_key = file(local.ssh_pub_key_path)
     }
     PRIORITYSPOT
     EVICTIONPOLICY


### PR DESCRIPTION
# Description                                                                                                                                                                               
When no public key is set in the scenario (ssh_pub_key: none_designated), ssh_pub_key_path ends up empty and file("") rashes trying to read the current directory as a file. Added a locals block that falls back to "${var.ssh_key_path}.pub" when ssh_pub_key_path is empty, so Terraform always gets a valid file path. This matches how GCP already handles it in this codebase.

# Before/After Comparison
A scenario without ssh_pub_key_file causes Terraform to crash at plan time:
```
resource_group_name = (known after apply)
╷
│ Error: Invalid function argument
│
│ on main.tf line 129, in resource "azurerm_linux_virtual_machine" "virtualmachine":
│ 129: public_key = file(var.ssh_pub_key_path)
│ ├────────────────
│ │ while calling file(path)
│ │ var.ssh_pub_key_path is ""
│
│ Invalid value for "path" parameter: failed to read file: read .: is a
│ directory.
```

 After: Terraform derives the public key path from the private key path (e.g. ~/.ssh/id_rsa → ~/.ssh/id_rsa.pub) and proceeds normally. If ssh_pub_key_file is explicitly set in the scenario, that value still takes precedence.

# Documentation Check                                                                                                                                                                       
No documentation updates needed. 

# Clerical Stuff
This closes #420
Relates to JIRA: RPOPC-1356