### PR TITLE
Add CI to create images for releases

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -4,6 +4,10 @@ on:
       - main
   pull_request:
 
+env:
+  IMAGE_REGISTRY: quay.io
+  IMAGE_NAME: quay.io/zathras/zathras
+
 jobs:
   containerize:
     runs-on: ubuntu-latest
@@ -14,7 +18,7 @@ jobs:
         if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
-          registry: quay.io
+          registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_UNAME }}
           password: ${{ secrets.QUAY_PASSWD }}
         
@@ -26,7 +30,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: quay.io/zathras/zathras:latest
+          tags: ${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
@@ -37,7 +41,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: false
-          tags: quay.io/zathras/zathras:latest
+          tags: ${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           platforms: linux/amd64,linux/arm64
           file: Containerfile

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   IMAGE_REGISTRY: quay.io
-  IMAGE_NAME: quay.io/zathras/zathras
+  IMAGE_NAME: zathras/zathras
 
 jobs:
   containerize:
@@ -24,12 +24,24 @@ jobs:
         
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
+      
+      - name: Build tag list
+        run: |
+          IMAGE_BASE=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          IMAGE_TAGS=${IMAGE_BASE}:${{ github.sha }}
+
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            IMAGE_TAGS="${IMAGE_TAGS},${IMAGE_BASE}:latest"
+          fi
+          
+          echo "IMAGE_TAGS=$IMAGE_TAGS" >> $GITHUB_ENV
 
       - name: Build Container
         uses: docker/build-push-action@v6
         with:
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ env.IMAGE_URL }}:latest
+          tags: ${{ env.IMAGE_TAGS }}
+          provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -7,6 +7,7 @@ on:
 env:
   IMAGE_REGISTRY: quay.io
   IMAGE_NAME: zathras/zathras
+  RELEASE_TAG: ${{ github.ref_name }}
 
 jobs:
   containerize:
@@ -15,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Login to Quay
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'release'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.IMAGE_REGISTRY }}
@@ -33,17 +34,23 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" ]]; then
             IMAGE_TAGS="${IMAGE_TAGS},${IMAGE_BASE}:latest"
           elif [[ "${{ github.event_name }}" == "release" ]]; then
-            LOCAL_MAJOR=$(echo "${{ github.ref_name }}" | cut -d'.' -f1)
-            LOCAL_MINOR=$(echo "${{ github.ref_name }}" | cut -d'.' -f2)
-            LOCAL_PATCH=$(echo "${{ github.ref_name }}" | cut -d'.' -f3)
+            LOCAL_MAJOR=$(echo "$RELEASE_TAG" | cut -d'.' -f1)
+            LOCAL_MINOR=$(echo "$RELEASE_TAG" | cut -d'.' -f2)
+            LOCAL_PATCH=$(echo "$RELEASE_TAG" | cut -d'.' -f3)
             
+
+            REMOTE_JSON=$(skopeo list-tags docker://$IMAGE_BASE)
+            if [[ $? -ne 0 ]]; then
+              echo "::error::Could not query $IMAGE_BASE for image tags"
+              exit 1
+            fi
             # Don't care about other majors
-            REMOTE_TAGS=$( (skopeo list-tags docker://$IMAGE_BASE | jq -r '.Tags[]' | grep -E "^$LOCAL_MAJOR\.") || echo "" && echo "${{ github.ref_name }}")
-            if [[ $(echo "$REMOTE_TAGS" | sort -V | tail -n1) == "${{ github.ref_name}}" ]]; then
+            REMOTE_TAGS=$(echo "$REMOTE_JSON" | jq -r '.Tags[]' | grep -E "^$LOCAL_MAJOR\." || echo ""; echo "$RELEASE_TAG")
+            if [[ $(echo "$REMOTE_TAGS" | sort -V | tail -n1) == "$RELEASE_TAG" ]]; then
               IMAGE_TAGS="${IMAGE_TAGS},${IMAGE_BASE}:${LOCAL_MAJOR}"
             fi
 
-            IMAGE_TAGS="${IMAGE_TAGS},${IMAGE_BASE}:${LOCAL_MAJOR}.${LOCAL_MINOR},${IMAGE_BASE}:${{ github.ref_name }}"
+            IMAGE_TAGS="${IMAGE_TAGS},${IMAGE_BASE}:${LOCAL_MAJOR}.${LOCAL_MINOR},${IMAGE_BASE}:$RELEASE_TAG"
           fi
           echo "$IMAGE_TAGS"
           echo "IMAGE_TAGS=$IMAGE_TAGS" >> $GITHUB_ENV

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -3,6 +3,9 @@ on:
     branches:
       - main
   pull_request:
+  release:
+    types:
+      - published
 
 env:
   IMAGE_REGISTRY: quay.io

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -25,23 +25,12 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
-        if: github.event_name == 'push'
+      - name: Build Container
         uses: docker/build-push-action@v6
         with:
-          push: true
-          tags: ${{ env.IMAGE_NAME }}:latest
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ env.IMAGE_URL }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
-          file: Containerfile
-
-      - name: Build
-        if: github.event_name != 'push'
-        uses: docker/build-push-action@v6
-        with:
-          push: false
-          tags: ${{ env.IMAGE_NAME }}:latest
-          cache-from: type=gha
           platforms: linux/amd64,linux/arm64
           file: Containerfile

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -32,14 +32,26 @@ jobs:
 
           if [[ "${{ github.event_name }}" == "push" ]]; then
             IMAGE_TAGS="${IMAGE_TAGS},${IMAGE_BASE}:latest"
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            LOCAL_MAJOR=$(echo "${{ github.ref_name }}" | cut -d'.' -f1)
+            LOCAL_MINOR=$(echo "${{ github.ref_name }}" | cut -d'.' -f2)
+            LOCAL_PATCH=$(echo "${{ github.ref_name }}" | cut -d'.' -f3)
+            
+            # Don't care about other majors
+            REMOTE_TAGS=$( (skopeo list-tags docker://$IMAGE_BASE | jq -r '.Tags[]' | grep -E "^$LOCAL_MAJOR\.") || echo "" && echo "${{ github.ref_name }}")
+            if [[ $(echo "$REMOTE_TAGS" | sort -V | tail -n1) == "${{ github.ref_name}}" ]]; then
+              IMAGE_TAGS="${IMAGE_TAGS},${IMAGE_BASE}:${LOCAL_MAJOR}"
+            fi
+
+            IMAGE_TAGS="${IMAGE_TAGS},${IMAGE_BASE}:${LOCAL_MAJOR}.${LOCAL_MINOR},${IMAGE_BASE}:${{ github.ref_name }}"
           fi
-          
+          echo "$IMAGE_TAGS"
           echo "IMAGE_TAGS=$IMAGE_TAGS" >> $GITHUB_ENV
 
       - name: Build Container
         uses: docker/build-push-action@v6
         with:
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' || github.event_name == 'release' }}
           tags: ${{ env.IMAGE_TAGS }}
           provenance: false
           cache-from: type=gha


### PR DESCRIPTION
# Description
This updates the CI/CD workflow for containerizing Zathras.  A few flows exist:
1. All containers are given a SHA commit ID for a tag
2. Pushes to `main` update the `latest` tag
3. Cutting a GitHub release will trigger a version number build
   - If it's the latest of a major version, the major version number tag is updated
   - Otherwise the minor and full version tags are put on it
     - For example, if 2.1.0 exists and we create 2.0.9, the `2` tag remains at `2.1.0` and NOT `2.0.9`
     - If 2.1.1 is created under this same example, that version receives `2`,`2.1` and `2.1.1` tags for the container

# Before/After Comparison
## Before
We only containerized the main branch which can be unstable.

## After
We containerize `main` for testing purposes and then cut a release once things are stable.

# Documentation Check
Workflow documents might need updating.

# Clerical Stuff
This closes #419 
Relates to JIRA: RPOPC-1355
