### PR TITLE
[IBM] Remove double prefix on do_not_install_system_packages

### DIFF
--- a/bin/ten_of_us.yml
+++ b/bin/ten_of_us.yml
@@ -330,7 +330,7 @@
       when:
         - config_info.system_type == "ibm"
         - config_info.do_not_install_packages == 0
-        - config_info.config_info.do_not_install_system_packages == 0
+        - config_info.do_not_install_system_packages == 0
 
     - name: retrieve repo config status
       include_role:


### PR DESCRIPTION
# Description
Removes a double prefix for do_not_install_system_packages in IBM cloud when installing CRB repos.

# Before/After Comparison
## Before
From #408
> The `do_not_install_system_packages` flag is never read correctly. Tasks that should be skipped when `--no_system_packages` is set still run.

## After
The CRB task now receives the correct `do_not_install_system_packages` value

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

No documentation changes needed, bugfix

# Clerical Stuff
This closes #408 

Relates to JIRA: RPOPC-1325
