### PR TITLE
feat: Add data volume support to ibm_create role

### DIFF
--- a/ansible_roles/roles/ibm_create/files/tf/disks.tf
+++ b/ansible_roles/roles/ibm_create/files/tf/disks.tf
@@ -1,0 +1,23 @@
+resource "ibm_is_volume" "data_volume" {
+  count          = var.vm_count * var.disk_count
+  name           = "${var.run_label}-volume-${format("%02d", count.index)}"
+  profile        = var.disk_profile
+  zone           = var.zone
+  capacity       = var.disk_size
+  resource_group = var.resource_group_id
+  tags           = [var.User, var.Project, var.run_label]
+}
+
+resource "ibm_is_instance_volume_attachment" "volume_attachment" {
+  count    = var.vm_count * var.disk_count
+  instance = element(
+    ibm_is_instance.test.*.id,
+    floor(count.index / var.disk_count)
+  )
+  volume = element(
+    ibm_is_volume.data_volume.*.id,
+    count.index
+  )
+  name                             = "${var.run_label}-attachment-${format("%02d", count.index)}"
+  delete_volume_on_instance_delete = true
+}

--- a/ansible_roles/roles/ibm_create/files/tf/vars.tf
+++ b/ansible_roles/roles/ibm_create/files/tf/vars.tf
@@ -63,3 +63,21 @@ variable "resource_group_id" {
   type        = string
   default     = ""
 }
+
+variable "disk_count" {
+  description = "Number of data volumes per instance"
+  type        = number
+  default     = 0
+}
+
+variable "disk_size" {
+  description = "Size of each data volume in GB"
+  type        = number
+  default     = 100
+}
+
+variable "disk_profile" {
+  description = "IBM Cloud volume profile"
+  type        = string
+  default     = "general-purpose"
+}

--- a/ansible_roles/roles/ibm_create/tasks/disks.yml
+++ b/ansible_roles/roles/ibm_create/tasks/disks.yml
@@ -1,0 +1,28 @@
+---
+- name: Grab number of disks
+  shell: "echo \"{{ config_info.cloud_disks }}\" | cut -d: -f 1 | cut -d\"'\" -f 2"
+  register: disk_count_raw
+
+- name: Grab disk type
+  shell: "echo \"{{ config_info.cloud_disks }}\" | cut -d: -f 2"
+  register: disk_type_raw
+
+- name: Grab disk size
+  shell: "echo \"{{ config_info.cloud_disks }}\" | cut -d: -f 3"
+  register: disk_size_raw
+
+- name: Set disk variables
+  set_fact:
+    disk_count: "{{ disk_count_raw.stdout }}"
+    disk_type: "{{ disk_type_raw.stdout }}"
+    disk_size: "{{ disk_size_raw.stdout }}"
+
+- name: Copy disks.tf to work location
+  copy:
+    src: tf/disks.tf
+    dest: "{{ working_dir }}/tf/"
+
+- name: Update tfvars with disk settings
+  blockinfile:
+    dest: "{{ working_dir }}/tf/env.tfvars"
+    block: "{{ lookup('template', 'tfvars_disks.j2') }}"

--- a/ansible_roles/roles/ibm_create/tasks/main.yml
+++ b/ansible_roles/roles/ibm_create/tasks/main.yml
@@ -74,6 +74,10 @@
     src: "{{ working_dir }}/tfvars.j2"
     dest: "{{ working_dir }}/tf/env.tfvars"
 
+- name: Handle disks
+  include_tasks: disks.yml
+  when: config_info.cloud_disks != "none" and "'0:na:na:0' not in config_info.cloud_disks"
+
 - name: grab create start time
   command: "date -u +%s"
   register: create_time_start

--- a/ansible_roles/roles/ibm_create/templates/tfvars_disks.j2
+++ b/ansible_roles/roles/ibm_create/templates/tfvars_disks.j2
@@ -1,0 +1,7 @@
+disk_profile = "general-purpose"
+disk_count = {{ disk_count }}
+disk_size = {{ disk_size }}
+
+{% if disk_type == "gp3" %}
+disk_profile = "custom"
+{% endif %}


### PR DESCRIPTION
# Description 
 Add data volume (block storage) support to the ibm_create Terraform role. Parses the Disks parameter from host_config, creates IBM Cloud block storage volumes via Terraform, and attaches them to instances. Matches existing disk handling in AWS, Azure, and GCP create roles.

New files: disks.tf, disks.yml, tfvars_disks.j2
Modified: vars.tf (new variables), tasks/main.yml (include disks.yml)

# Before/After Comparison
Before: `host_config: "bx2-4x16:Disks;number=1;size=100;type=general-purpose"` was parsed but IBM Cloud instances were created without any data volumes.

After: The same config creates a 100GB general-purpose volume and attaches it to the instance. Verified end-to-end with fio on IBM Cloud us-east.

# Documentation Check
No documentation updates needed. The host_config Disks syntax is the same format already used by other cloud providers.

# Clerical Stuff
This closes #425

Relates to JIRA: RPOPC-1387