### PR TITLE
[Azure] use az sig image-version show for gallery image verification

### DIFF
--- a/bin/burden
+++ b/bin/burden
@@ -514,8 +514,7 @@ azure_image_lookup()
 				az vm image show --urn $urn --output tsv 2>&1 > /dev/null
 				rtc=$?
 			else
-				resource_group=`echo $urn | cut -d'/' -f 5`
-				az resource list --resource-group $resource_group | grep -q $urn
+				az sig image-version show --ids $urn --output none 2>/dev/null
 				rtc=$?
 			fi
 			if [[ $rtc -ne 0 ]]; then


### PR DESCRIPTION
# Description
Replace broken az resource list --resource-group $resource_group | grep -q $urn command with az sig image-version show --ids $urn --output none for verifying Azure Shared Image Gallery images in bin/burden. The old command doesn't return gallery image versions (they are nested ARM resources), causing grep to fail and burden to exit with "does not exist" before terraform runs.

# Before/After Comparison

###BEFORE:

Error: Requested Azure image /subscriptions/0f15d975-3110-4b83-934d-802cb96d6cc4/resourceGroups/RPOPC-CPT-PIPELINE-RG/providers/Microsoft.Compute/galleries/rpopccptPipelineGallery/images/rhel-10.2-x86_64/versions/1.0.1783692675, does not exist
Finished run_burden_1245260_0

###AFTER

Image accepted and burden proceeds with task  

{'global': {'terminate_cloud': 1, 'cloud_os_id': '/subscriptions/0f15d975-3110-4b83-934d-802cb96d6cc4/resourceGroups/RPOPC-CPT-PIPELINE-RG/providers/Microsoft.Compute/galleries/rpopccptPipelineGallery/images/rhel-10.2-x86_64/versions/1.0.1783692675', 'os_vendor': 'rhel', 'system_type': 'azure'}, 'systems': {'system1': {'results_prefix': 'test_tf_rescue_azure', 'tests': 'coremark', 'host_config': 'Standard_D4s_v3'}}}
WARNING: This command has been deprecated and will be removed in a future release. Use 'az vm list-skus' instead.
Standard_D4s_v3
No spot price designated, retrieving
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   167    0   167    0     0   1208      0 --:--:-- --:--:-- --:--:--  1210
100  306k    0  306k    0     0   184k      0 --:--:--  0:00:01 --:--:--  574k
Starting coremark on Standard_D4s_v3
mkdir: cannot create directory ‘tf’: File exists
===== attempt 1 of 5 ==============

PLAY [local] *******************************************************************


# Documentation Check
No documentation updates needed. This is a bugfix to an internal az CLI call.

# Clerical Stuff

Solves: #411 
Relates to JIRA: RPOPC-1328
