### PR TITLE
Add Partial Azure and IBMCloud support to images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,10 @@ FROM registry.fedoraproject.org/fedora:43
 
 RUN dnf config-manager addrepo --from-repofile=https://rpm.releases.hashicorp.com/fedora/hashicorp.repo && \
     dnf install -y ssh-agent terraform python3-pip ansible-core hostname gh jq bc && pip3 install awscli
+RUN pip3 install azure-cli
+RUN curl -fsSL https://clis.cloud.ibm.com/install/linux | sh && \
+    ibmcloud plugin install vpc-infrastructure -f && \
+    ibmcloud plugin install cloud-object-storage -f
 # SSH directory management since it'll be needed later
 RUN mkdir ~/.ssh && chmod 700 ~/.ssh
 

--- a/docs/container.md
+++ b/docs/container.md
@@ -7,9 +7,17 @@
 |------------|-----------|
 | Local Systems | :white_check_mark: |
 | AWS | :white_check_mark:|
-| Azure | :x: |
+| Azure | :construction: |
 | GCP | :x: |
-| IBM Cloud | :x: |
+| IBM Cloud | :construction: |
+
+:white_check_mark: - Full support, should be able to use the default entrypoint
+
+:construction: - Works but requires manual command invocations, requiring 
+changing the container entrypoint by using something like
+`--entrypoint /bin/bash`.
+
+:x: - No support, should work but needs package installation in order to function.
 
 ## Volumes
 
@@ -29,8 +37,20 @@ Local configs should be placed in a volume, but it cannot be mounted anywhere, i
 `-v $CONFIG_PATH:/zathras/local_configs`
 
 ## Enviornment Variables
-| Variable Name | Cloud Type | Purpose |
-|---------------|------------|---------|
-| `AWS_ACCESS_KEY_ID` | AWS | Credentials to create AWS systems |
-| `AWS_SECRET_ACCESS_KEY` | AWS | Credentials to create AWS systems |
-| `AWS_DEFAULT_REGION` | AWS | Region to create the AWS system(s) |
+### AWS
+| Variable Name | Purpose |
+|---------------|---------|
+| `AWS_ACCESS_KEY_ID` | Credentials to create AWS systems |
+| `AWS_SECRET_ACCESS_KEY` | Credentials to create AWS systems |
+| `AWS_DEFAULT_REGION` | Region to create the AWS system(s) |
+
+### Azure
+Requires `az login` to run.  Consult the [documentation](https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest)
+on how to provide the needed information.
+
+### IBMCloud
+Requires `ibmcloud login` to function.  Consult the [documentation](https://cloud.ibm.com/docs/cli?topic=cli-ibmcloud_cli#ibmcloud_login)
+on how to provide the needed information.
+
+Once logged in, run `ibmcloud target -g <resource group name>` to set the resource group.
+


### PR DESCRIPTION
# Description
This PR adds the tools needed to work with Azure and IBMCloud to the Zathras container image, enabling it to easily run on those enviornments.

# Before/After Comparison
## Before
In order to run on Azure or IBMCloud, we needed to manually install the CLI packages.

## After
The CLI packages for both Azure and IBMCloud are provided in the image.  Currently they require a manual login step since they don't support credentials to be provided via environment variables.

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

Yes, documentation was updated.

# Clerical Stuff
Closes #426 
Relates to JIRA: RPOPC-1388
