### PR TITLE
[Azure] Fix name of template file with networking and private image

### DIFF
--- a/ansible_roles/roles/azure_create/tasks/main.yml
+++ b/ansible_roles/roles/azure_create/tasks/main.yml
@@ -47,7 +47,7 @@
   - name: copy main_net_p2_sub.tf to work area for later use
     block:
     - name: copy for subscription urn, private
-      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/main_net_sub.tf | sed \"s/PRIORITYSPOT/priority              = \\\"Spot\\\"/g\" | sed \"s/EVICTIONPOLICY/eviction_policy       = \\\"Deallocate\\\"/g\"  >> {{ working_dir }}/tf/main_net_p2.tf"
+      shell: "cat {{ config_info.local_run_dir }}/ansible_roles/roles/azure_create/files/tf/main_net_p2_sub.tf | sed \"s/PRIORITYSPOT/priority              = \\\"Spot\\\"/g\" | sed \"s/EVICTIONPOLICY/eviction_policy       = \\\"Deallocate\\\"/g\"  >> {{ working_dir }}/tf/main_net_p2.tf"
     when: config_info.cloud_os_version == "none"
   - name: copy output.tf to tf/output_net.tf
     copy:


### PR DESCRIPTION
# Description
Fixes the terraform network file name used for instances that have networking while using a private image.  `main_net_sub.tf` does not exist within this repository.

# Before/After Comparison
## Before
Runs with private images and networking resulted in terraform failures.  Since the file `main_net_sub.tf` does not exist, the desired file would be empty, preventing resources from being defined, and that ultimately results in errors when registering outputs.

## After
Runs with private images and networking works as intended

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

No docs needed, bugfix

# Clerical Stuff
This closes #410 

Relates to JIRA: RPOPC-1327
