### PR TITLE
fix(ci): PRs with commented state now are inprogress

### DIFF
--- a/ci/issue-tagging-container/determine_status.py
+++ b/ci/issue-tagging-container/determine_status.py
@@ -4,18 +4,20 @@ import json
 
 def _main(file):
 	data = json.load(file)
-
+	approved = False
 	for review in data['latestReviews']:
 		if review['state'] == "CHANGES_REQUESTED":
 			return "inprogress"
+		elif review['state'] == 'APPROVED':
+			approved = True
 	
 	if len(data['reviewRequests']) > 0:
 		return "review"
 
-	if len(data['latestReviews']) > 0:
+	if len(data['latestReviews']) > 0 and approved:
 		return "approved"
 	
-	return "inprogress" #No PR Requests and no reviews
+	return "inprogress" #No PR Requests and no reviews, or only comments
 
 if __name__ == "__main__":
 	import sys


### PR DESCRIPTION
# Description
Previously the determine_status script would flag a PR with only a single "review" in "Commented" state as "approved".  This is now fixed.

# Before/After Comparison
## Before
A PR with a "commented" review would apply an "approved" label

## After
"Commented" reviews are ignored.

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

No, developer workflow bugfix

# Clerical Stuff
This closes #437 
Relates to JIRA: RPOPC-1444
