### PR TITLE
fix(azure): Move disks.tf when there's actually disks to work with

### DIFF
--- a/ansible_roles/roles/azure_create/tasks/main.yml
+++ b/ansible_roles/roles/azure_create/tasks/main.yml
@@ -85,7 +85,7 @@
     copy:
       src: "tf/disks.tf"
       dest: "{{ working_dir }}/tf/disks.tf"
-  when: config_info.cloud_disks != "[0:na:na:0]"
+  when: config_info.cloud_disks != "[0:na:na:0]" and config_info.cloud_disks != "none"
 
 - name: include variables etc.
   include_vars:


### PR DESCRIPTION
# Description
Adds a simple check to see if the cloud_disks is "none"

# Before/After Comparison
## Before
On Azure, when `cloud_disks` is "none" the handle disks block in `ansible_roles/roles/azure_create/tasks/main.yml` would run, copying the `disk.tf` file when it's not needed.

## After
The entire handle disk block is skipped when there are no disks to deal with

# Documentation Check
Does this change require any updates to user-facing or internal documentation?
If "yes", were those updates made?

No, internal bugfix

# Clerical Stuff
Closes #413 

Relates to JIRA: RPOPC-1330
