### PR TITLE
Fix/ibm cloud networking

### DIFF
--- a/ansible_roles/roles/ibm_create/tasks/main.yml
+++ b/ansible_roles/roles/ibm_create/tasks/main.yml
@@ -147,3 +147,12 @@
 
 - name: Add host to test and install groups
   include_tasks: add_host_to_groups.yml
+
+- name: Setup SSH key exchange for inter-VM communication (required for uperf)
+  include_role:
+    name: ssh_key_exchange
+  vars:
+    ip_list:
+      - "{{ public_ip_list[0] }}"
+      - "{{ public_ip_list[1] }}"
+  when: public_ip_list | length > 1

--- a/ansible_roles/roles/ibm_create/tasks/record_ip_info.yml
+++ b/ansible_roles/roles/ibm_create/tasks/record_ip_info.yml
@@ -75,3 +75,17 @@
     path: "{{ working_dir }}/ansible_run_vars.yml"
     regexp: "^ssh_i_option:"
     line: "ssh_i_option: -i {{ config_info.ssh_key }}"
+
+- name: Record uperf server IP for network tests
+  lineinfile:
+    path: "{{ working_dir }}/ansible_run_vars.yml"
+    regexp: "^ct_uperf_server_ip:"
+    line: "ct_uperf_server_ip: {{ private_ip_list[0] }}"
+  when: private_ip_list is defined and private_ip_list | length > 1
+
+- name: Record uperf client list for network tests
+  lineinfile:
+    path: "{{ working_dir }}/ansible_run_vars.yml"
+    regexp: "^ct_uperf_client_list:"
+    line: "ct_uperf_client_list: {{ private_ip_list[1] }}"
+  when: private_ip_list is defined and private_ip_list | length > 1


### PR DESCRIPTION
# Description
Enable uperf network testing on IBM VPC by recording server/client IPs and setting up inter-VM root SSH, matching AWS/Azure/GCP behavior

# Before/After Comparison
Before: uperf on IBM fails with `'dict object' has no attribute 'ct_uperf_server_ip'` or silently produces no results due to missing root SSH
After: uperf runs to completion on IBM VPC, same as all other cloud providers

# Documentation Check
Not required This aligns IBM with existing cloud provider provisioning flow

  # Clerical Stuff
  This closes #439

  Relates to JIRA: RPOPC-<TICKET_NUMBER>
