### PR TITLE
fix: clean up cloud resources on midrun failure

### DIFF
--- a/ansible_roles/roles/tf_create/tasks/tf_apply.yml
+++ b/ansible_roles/roles/tf_create/tasks/tf_apply.yml
@@ -32,6 +32,14 @@
     line: "rtc: {{ '0' if tf_success else '1' }}"
     backrefs: yes
 
+- name: Clean up partial resources on failure
+  when: not tf_success
+  include_role:
+    name: tf_delete
+  vars:
+    tf_dir: "tf"
+  ignore_errors: yes
+
 - name: Fail if terraform failed
   when: not tf_success
   ansible.builtin.fail:

--- a/bin/burden
+++ b/bin/burden
@@ -441,7 +441,7 @@ cleanup_and_exit_on_break()
 #
 # Signal catcher
 #
-trap cleanup_and_exit_on_break SIGINT
+trap cleanup_and_exit_on_break SIGINT SIGTERM
 
 #
 # Generate report of test status.

--- a/bin/utils/terraform_ops
+++ b/bin/utils/terraform_ops
@@ -35,11 +35,17 @@ tf_terminate()
 	for tf_del in $dirs; do
 		if [[ -d $tf_del ]]; then
 			pushd $tf_del > /dev/null
-			terraform show | grep -q "No resources"
+			terraform show 2>/dev/null | grep -q "No resources"
 			if [[ $? -ne 0 ]]; then
 				terraform plan -var-file=env.tfvars -destroy -out=destroy.tfplan
 				if [ $? -eq 0 ]; then
 					terraform apply "destroy.tfplan"
+					if [ $? -eq 0 ]; then
+						cd ..
+						rm -rf tf
+					else
+						echo "Warning: Destroy failed for $tf_del, keeping tf directory to avoid orphaned resources"
+					fi
 				else
 					#
 					# We do not want to exit out on an error.  The instance could have been
@@ -48,12 +54,10 @@ tf_terminate()
 					#
 					echo "Warning: Unable to create the plan for $tf_del"
 				fi
+			else
+				cd ..
+				rm -rf tf
 			fi
-			#
-			# Get rid of the tf directory
-			#
-			cd ..
-			rm -rf tf
 			popd > /dev/null
 		fi
 	done


### PR DESCRIPTION
Enable uperf on IBM Cloud and clean up cloud resources on midrun terraform failure.

# Before/After Comparison

Before: Uperf fails on IBM Cloud — server/client IPs aren't recorded and VMs can't SSH to each other. Terraform partial failures and pipeline timeouts leave orphaned VMs.

After: IPs recorded, SSH keys exchanged between VMs, partial terraform failures trigger cleanup, and burden traps SIGTERM for proper teardown.

# Documentation Check
No.

# Clerical Stuff
Relates to JIRA: RPOPC-<TICKET_NUMBER>
Solves: #387 #428 