### PR TITLE
fix(ibm): Add random suffix to resource names to prevent collisions

### DIFF
--- a/ansible_roles/roles/ibm_create/files/tf/main.tf
+++ b/ansible_roles/roles/ibm_create/files/tf/main.tf
@@ -4,8 +4,16 @@ terraform {
       source  = "IBM-Cloud/ibm"
       version = "~> 1.70"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
   required_version = ">= 1.0"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 2
 }
 
 # Configure the IBM Cloud Provider
@@ -22,22 +30,19 @@ data "ibm_is_vpc" "zathras_vpc" {
 # Get or create VPC
 resource "ibm_is_vpc" "zathras_vpc" {
   count          = var.vpc_name == "" ? 1 : 0
-  name           = "${var.run_label}-vpc-${formatdate("YYYYMMDDHHmmss", timestamp())}"
+  name           = "${local.name_prefix}-vpc"
   resource_group = var.resource_group_id
   tags           = [var.User, var.Project]
-
-  lifecycle {
-    ignore_changes = [name]
-  }
 }
 
 locals {
-  vpc_id = var.vpc_name != "" ? data.ibm_is_vpc.zathras_vpc[0].id : ibm_is_vpc.zathras_vpc[0].id
+  vpc_id      = var.vpc_name != "" ? data.ibm_is_vpc.zathras_vpc[0].id : ibm_is_vpc.zathras_vpc[0].id
+  name_prefix = "${var.run_label}-${random_id.suffix.hex}"
 }
 
 # Create subnet
 resource "ibm_is_subnet" "zathras_subnet" {
-  name                     = "${var.run_label}-${var.machine_type}-subnet"
+  name                     = "${local.name_prefix}-${var.machine_type}-subnet"
   vpc                      = local.vpc_id
   zone                     = var.zone
   total_ipv4_address_count = 256
@@ -46,7 +51,7 @@ resource "ibm_is_subnet" "zathras_subnet" {
 
 # Create security group
 resource "ibm_is_security_group" "zathras_sg" {
-  name           = "${var.run_label}-${var.machine_type}-sg"
+  name           = "${local.name_prefix}-${var.machine_type}-sg"
   vpc            = local.vpc_id
   resource_group = var.resource_group_id
 }
@@ -73,7 +78,7 @@ data "ibm_is_ssh_key" "zathras_ssh_key" {
 # Create VSI (Virtual Server Instance)
 resource "ibm_is_instance" "test" {
   count          = var.vm_count
-  name           = "${var.run_label}-${var.machine_type}-${count.index}"
+  name           = "${local.name_prefix}-${var.machine_type}-${count.index}"
   vpc            = local.vpc_id
   zone           = var.zone
   profile        = var.machine_type
@@ -108,7 +113,7 @@ resource "ibm_is_instance" "test" {
 # Create floating IP for public access
 resource "ibm_is_floating_ip" "zathras_floating_ip" {
   count          = var.vm_count
-  name           = "${var.run_label}-${var.machine_type}-fip-${count.index}"
+  name           = "${local.name_prefix}-${var.machine_type}-fip-${count.index}"
   target         = ibm_is_instance.test[count.index].primary_network_interface[0].id
   resource_group = var.resource_group_id
   tags           = [var.User, var.Project]
@@ -117,7 +122,7 @@ resource "ibm_is_floating_ip" "zathras_floating_ip" {
 # Create private subnets for additional networks
 resource "ibm_is_subnet" "zathras_private_subnet" {
   count                    = var.network_count
-  name                     = "${var.run_label}-${var.machine_type}-private-subnet-${count.index}"
+  name                     = "${local.name_prefix}-${var.machine_type}-private-subnet-${count.index}"
   vpc                      = local.vpc_id
   zone                     = var.zone
   total_ipv4_address_count = 256

--- a/ansible_roles/roles/ibm_create/files/tf/main.tf
+++ b/ansible_roles/roles/ibm_create/files/tf/main.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 resource "random_id" "suffix" {
-  byte_length = 2
+  byte_length = 4
 }
 
 # Configure the IBM Cloud Provider
@@ -36,8 +36,13 @@ resource "ibm_is_vpc" "zathras_vpc" {
 }
 
 locals {
-  vpc_id      = var.vpc_name != "" ? data.ibm_is_vpc.zathras_vpc[0].id : ibm_is_vpc.zathras_vpc[0].id
-  name_prefix = "${var.run_label}-${random_id.suffix.hex}"
+  vpc_id = var.vpc_name != "" ? data.ibm_is_vpc.zathras_vpc[0].id : ibm_is_vpc.zathras_vpc[0].id
+  # IBM Cloud caps names at 63 chars. Longest pattern here is
+  # "<run_label>-<suffix>-<machine_type>-private-subnet-<idx>": 9 (suffix) +
+  # 20 (worst-case machine_type) + 16 ("-private-subnet-") + 2 (idx) = 47
+  # reserved, leaving 15 chars for run_label.
+  run_label_safe = substr(var.run_label, 0, 15)
+  name_prefix    = "${local.run_label_safe}-${random_id.suffix.hex}"
 }
 
 # Create subnet

--- a/ansible_roles/roles/ibm_vpc_create/files/tf/disks.tf
+++ b/ansible_roles/roles/ibm_vpc_create/files/tf/disks.tf
@@ -1,7 +1,7 @@
 # Create regular data volumes
 resource "ibm_is_volume" "data_volume" {
   count          = var.vm_count * var.disk_count
-  name           = "${var.run_label}-volume-${format("%02d", count.index)}"
+  name           = "${local.name_prefix}-volume-${format("%02d", count.index)}"
   profile        = var.disk_profile
   zone           = var.zone
   capacity       = var.disk_size
@@ -20,6 +20,6 @@ resource "ibm_is_instance_volume_attachment" "volume_attachment" {
     ibm_is_volume.data_volume.*.id,
     count.index
   )
-  name     = "${var.run_label}-attachment-${format("%02d", count.index)}"
+  name     = "${local.name_prefix}-attachment-${format("%02d", count.index)}"
   delete_volume_on_instance_delete = true
 }

--- a/ansible_roles/roles/ibm_vpc_create/files/tf/main_net.tf
+++ b/ansible_roles/roles/ibm_vpc_create/files/tf/main_net.tf
@@ -4,6 +4,10 @@ terraform {
       source = "IBM-Cloud/ibm"
       version = "~> 1.49.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
   required_version = ">= 1.0"
 }
@@ -13,8 +17,13 @@ provider "ibm" {
   # API key authentication via environment variables (IC_API_KEY or IBMCLOUD_API_KEY)
 }
 
+resource "random_id" "suffix" {
+  byte_length = 2
+}
+
 locals {
-  tags = var.vpc_tags
+  tags        = var.vpc_tags
+  name_prefix = "${var.run_label}-${random_id.suffix.hex}"
 }
 
 # Define resource group
@@ -24,14 +33,14 @@ data "ibm_resource_group" "resource_group" {
 
 # Create virtual private cloud
 resource "ibm_is_vpc" "vpc" {
-  name           = "${var.run_label}-vpc"
+  name           = "${local.name_prefix}-vpc"
   resource_group = data.ibm_resource_group.resource_group.id
   tags           = local.tags
 }
 
 # Create public subnet
 resource "ibm_is_subnet" "subnet" {
-  name            = "${var.run_label}-subnet"
+  name            = "${local.name_prefix}-subnet"
   vpc             = ibm_is_vpc.vpc.id
   zone            = var.zone
   ipv4_cidr_block = "10.240.0.0/24"
@@ -40,7 +49,7 @@ resource "ibm_is_subnet" "subnet" {
 
 # Create private subnet
 resource "ibm_is_subnet" "private_subnet" {
-  name            = "${var.run_label}-private-subnet"
+  name            = "${local.name_prefix}-private-subnet"
   vpc             = ibm_is_vpc.vpc.id
   zone            = var.zone
   ipv4_cidr_block = "10.240.1.0/24"
@@ -49,7 +58,7 @@ resource "ibm_is_subnet" "private_subnet" {
 
 # Create security group
 resource "ibm_is_security_group" "security_group" {
-  name           = "${var.run_label}-sg"
+  name           = "${local.name_prefix}-sg"
   vpc            = ibm_is_vpc.vpc.id
   resource_group = data.ibm_resource_group.resource_group.id
 }
@@ -81,7 +90,7 @@ data "ibm_is_ssh_key" "ssh_key" {
 # Create instances
 resource "ibm_is_instance" "instance" {
   count          = var.vm_count
-  name           = "${var.run_label}-instance-${format("%02d", count.index)}"
+  name           = "${local.name_prefix}-instance-${format("%02d", count.index)}"
   vpc            = ibm_is_vpc.vpc.id
   zone           = var.zone
   profile        = var.machine_type

--- a/ansible_roles/roles/ibm_vpc_create/files/tf/main_net.tf
+++ b/ansible_roles/roles/ibm_vpc_create/files/tf/main_net.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ibm = {
-      source = "IBM-Cloud/ibm"
+      source  = "IBM-Cloud/ibm"
       version = "~> 1.49.0"
     }
     random = {
@@ -18,12 +18,16 @@ provider "ibm" {
 }
 
 resource "random_id" "suffix" {
-  byte_length = 2
+  byte_length = 4
 }
 
 locals {
-  tags        = var.vpc_tags
-  name_prefix = "${var.run_label}-${random_id.suffix.hex}"
+  tags = var.vpc_tags
+  # IBM Cloud caps names at 63 chars. Longest pattern here is
+  # "<run_label>-<suffix>-nic-private-<idx>": 9 (suffix) + 15
+  # ("-nic-private-<idx>") = 24 reserved, leaving 39 chars for run_label.
+  run_label_safe = substr(var.run_label, 0, 39)
+  name_prefix    = "${local.run_label_safe}-${random_id.suffix.hex}"
 }
 
 # Define resource group
@@ -68,7 +72,7 @@ resource "ibm_is_security_group_rule" "security_group_rule_ssh" {
   group     = ibm_is_security_group.security_group.id
   direction = "inbound"
   remote    = "0.0.0.0/0"
-  
+
   tcp {
     port_min = 22
     port_max = 22
@@ -97,16 +101,16 @@ resource "ibm_is_instance" "instance" {
   image          = var.image_name
   keys           = [data.ibm_is_ssh_key.ssh_key.id]
   resource_group = data.ibm_resource_group.resource_group.id
-  
+
   primary_network_interface {
     name            = "eth0"
     subnet          = ibm_is_subnet.subnet.id
     security_groups = [ibm_is_security_group.security_group.id]
   }
-  
+
   # Placement group can be configured here if needed
   # PRIORITYSPOT - will be replaced by Ansible
   # EVICTIONPOLICY - will be replaced by Ansible
-  
+
   tags = local.tags
 }

--- a/ansible_roles/roles/ibm_vpc_create/files/tf/main_no_net.tf
+++ b/ansible_roles/roles/ibm_vpc_create/files/tf/main_no_net.tf
@@ -4,6 +4,10 @@ terraform {
       source = "IBM-Cloud/ibm"
       version = "~> 1.49.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
   required_version = ">= 1.0"
 }
@@ -13,8 +17,13 @@ provider "ibm" {
   # API key authentication via environment variables (IC_API_KEY or IBMCLOUD_API_KEY)
 }
 
+resource "random_id" "suffix" {
+  byte_length = 2
+}
+
 locals {
-  tags = var.vpc_tags
+  tags        = var.vpc_tags
+  name_prefix = "${var.run_label}-${random_id.suffix.hex}"
 }
 
 # Define resource group
@@ -24,14 +33,14 @@ data "ibm_resource_group" "resource_group" {
 
 # Create virtual private cloud
 resource "ibm_is_vpc" "vpc" {
-  name           = "${var.run_label}-vpc"
+  name           = "${local.name_prefix}-vpc"
   resource_group = data.ibm_resource_group.resource_group.id
   tags           = local.tags
 }
 
 # Create public subnet
 resource "ibm_is_subnet" "subnet" {
-  name            = "${var.run_label}-subnet"
+  name            = "${local.name_prefix}-subnet"
   vpc             = ibm_is_vpc.vpc.id
   zone            = var.zone
   ipv4_cidr_block = "10.240.0.0/24"
@@ -40,7 +49,7 @@ resource "ibm_is_subnet" "subnet" {
 
 # Create security group
 resource "ibm_is_security_group" "security_group" {
-  name           = "${var.run_label}-sg"
+  name           = "${local.name_prefix}-sg"
   vpc            = ibm_is_vpc.vpc.id
   resource_group = data.ibm_resource_group.resource_group.id
 }
@@ -72,7 +81,7 @@ data "ibm_is_ssh_key" "ssh_key" {
 # Create instances
 resource "ibm_is_instance" "instance" {
   count          = var.vm_count
-  name           = "${var.run_label}-instance-${format("%02d", count.index)}"
+  name           = "${local.name_prefix}-instance-${format("%02d", count.index)}"
   vpc            = ibm_is_vpc.vpc.id
   zone           = var.zone
   profile        = var.machine_type

--- a/ansible_roles/roles/ibm_vpc_create/files/tf/main_no_net.tf
+++ b/ansible_roles/roles/ibm_vpc_create/files/tf/main_no_net.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ibm = {
-      source = "IBM-Cloud/ibm"
+      source  = "IBM-Cloud/ibm"
       version = "~> 1.49.0"
     }
     random = {
@@ -18,12 +18,17 @@ provider "ibm" {
 }
 
 resource "random_id" "suffix" {
-  byte_length = 2
+  byte_length = 4
 }
 
 locals {
-  tags        = var.vpc_tags
-  name_prefix = "${var.run_label}-${random_id.suffix.hex}"
+  tags = var.vpc_tags
+  # IBM Cloud caps names at 63 chars. Longest pattern here is
+  # "<run_label>-<suffix>-attachment-<idx>": 9 (suffix) + 14
+  # ("-attachment-<idx>") = 23 reserved, leaving 39 chars for run_label
+  # (kept consistent with main_net.tf's budget for this module).
+  run_label_safe = substr(var.run_label, 0, 39)
+  name_prefix    = "${local.run_label_safe}-${random_id.suffix.hex}"
 }
 
 # Define resource group
@@ -59,7 +64,7 @@ resource "ibm_is_security_group_rule" "security_group_rule_ssh" {
   group     = ibm_is_security_group.security_group.id
   direction = "inbound"
   remote    = "0.0.0.0/0"
-  
+
   tcp {
     port_min = 22
     port_max = 22
@@ -88,16 +93,16 @@ resource "ibm_is_instance" "instance" {
   image          = var.image_name
   keys           = [data.ibm_is_ssh_key.ssh_key.id]
   resource_group = data.ibm_resource_group.resource_group.id
-  
+
   primary_network_interface {
     name            = "eth0"
     subnet          = ibm_is_subnet.subnet.id
     security_groups = [ibm_is_security_group.security_group.id]
   }
-  
+
   # Placement group can be configured here if needed
   # PRIORITYSPOT - will be replaced by Ansible
   # EVICTIONPOLICY - will be replaced by Ansible
-  
+
   tags = local.tags
 }

--- a/ansible_roles/roles/ibm_vpc_create/files/tf/network_interface.tf
+++ b/ansible_roles/roles/ibm_vpc_create/files/tf/network_interface.tf
@@ -2,7 +2,7 @@
 resource "ibm_is_instance_network_interface" "secondary_interface" {
   count          = var.vm_count
   instance       = element(ibm_is_instance.instance.*.id, count.index)
-  name           = "${var.run_label}-nic-private-${format("%02d", count.index)}"
+  name           = "${local.name_prefix}-nic-private-${format("%02d", count.index)}"
   subnet         = ibm_is_subnet.private_subnet.id
   security_groups = [ibm_is_security_group.security_group.id]
 }

--- a/ansible_roles/roles/ibm_vpc_create/files/tf/output_net.tf
+++ b/ansible_roles/roles/ibm_vpc_create/files/tf/output_net.tf
@@ -25,7 +25,7 @@ output "instance_name1" {
 # Output for the public IP - using floating IP
 resource "ibm_is_floating_ip" "floating_ip" {
   count          = var.vm_count
-  name           = "${var.run_label}-fip-${format("%02d", count.index)}"
+  name           = "${local.name_prefix}-fip-${format("%02d", count.index)}"
   target         = ibm_is_instance.instance[count.index].primary_network_interface[0].id
   resource_group = data.ibm_resource_group.resource_group.id
 }

--- a/ansible_roles/roles/ibm_vpc_create/files/tf/output_no_net.tf
+++ b/ansible_roles/roles/ibm_vpc_create/files/tf/output_no_net.tf
@@ -13,7 +13,7 @@ output "instance_name0" {
 # Output for the public IP - using floating IP
 resource "ibm_is_floating_ip" "floating_ip" {
   count          = var.vm_count
-  name           = "${var.run_label}-fip-${format("%02d", count.index)}"
+  name           = "${local.name_prefix}-fip-${format("%02d", count.index)}"
   target         = ibm_is_instance.instance[count.index].primary_network_interface[0].id
   resource_group = data.ibm_resource_group.resource_group.id
 }


### PR DESCRIPTION
# Description
Adds a `random_id` with `byte_length=2` (4 hex chars) to both `ibm_create` and `ibm_vpc_create` roles. All resource names now include the suffix via a shared `local.name_prefix`, preventing Terraform name collisions on re-runs or parallel runs for the same compose + instance type.

Closes #427

# Before/After Comparison

## Before
Resource names are deterministic and based solely on `run_label`:
```
sbhavsar-rhel-bx2-4x16-subnet
sbhavsar-rhel-bx2-4x16-sg
sbhavsar-rhel-bx2-4x16-0
sbhavsar-rhel-bx2-4x16-fip-0
```
Two runs with the same compose + instance type produce identical names. The second run fails with `instance name already in use`.

## After
Each Terraform apply generates a unique 4-char hex suffix via `random_id`:
```
sbhavsar-rhel-a1b2-bx2-4x16-subnet
sbhavsar-rhel-a1b2-bx2-4x16-sg
sbhavsar-rhel-a1b2-bx2-4x16-0
sbhavsar-rhel-a1b2-bx2-4x16-fip-0
```
Re-runs and parallel runs get different suffixes, no collisions. The suffix is stable within a single Terraform state (won't change on re-plan), and adds 5 characters to each name, keeping all names within the 63-character IBM Cloud limit.

# Documentation Check
No documentation changes needed.

# Clerical Stuff
Closes #427

Relates to JIRA: RPOPC-1413